### PR TITLE
Fix problem with named plugins after multiple invocations

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,8 +20,10 @@ function createTestBot(opts) {
   if(!opts.keys)
     var keys = ssbKeys.generate()
 
-  if(plugins.length)
+  if(plugins.length) {
     plugins.forEach(plugin => createSbot.use(plugin))
+    plugins = []
+  }
 
   return createSbot({keys, temp: opts.name})
 }
@@ -31,4 +33,4 @@ createTestBot.use = function(plugin) {
   return createTestBot
 }
 
-module.exports = createTestBot 
+module.exports = createTestBot

--- a/test/index.js
+++ b/test/index.js
@@ -11,8 +11,8 @@ test('creates an sbot', function(t) {
 
 test('adds an sbot plugin and can be chained', function(t) {
   CreateTestSbot
-    .use({init: ()=>{}})
-    .use({init: ()=>{}})
+    .use({init: ()=>{}, name: 'fakePlugin1'})
+    .use({init: ()=>{}, name: 'fakePlugin2'})
 
   sbot = CreateTestSbot()
 


### PR DESCRIPTION
This makes it so plugins only get `.use`d on createSbot once. I noticed that the following causes an error:

```js
createTestBot.use({init: () => {}, name: 'radPlugin'})
createTestBot().close()
createTestBot().close()  // here we'll get "Error: plugin named:radPlugin is already loaded"
```

My first commit makes the tests fail due to this problem, and the second fixes it