### PR TITLE
updated dependencies. most significantly, moved to latest `ssb-server`

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,8 +7,8 @@ var plugins = []
 function createTestBot (opts) {
   opts = opts || {}
 
-  var createSbot = require('scuttlebot')
-  if (createSbot.createSbot) { createSbot = createSbot.createSbot() }
+  var createSbot = require('ssb-server')
+  if (createSbot.createSsbServer) { createSbot = createSbot.createSsbServer() }
 
   if (!opts.name) { opts.name = 'ssb-test-' + Number(new Date()) }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,561 +4,91 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "abstract-leveldown": {
-      "version": "0.12.4",
-      "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-0.12.4.tgz",
-      "integrity": "sha1-KeGOYy5g5OIh1YECR4UqY9ey5BA=",
-      "requires": {
-        "xtend": "3.0.0"
-      },
-      "dependencies": {
-        "xtend": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
-          "integrity": "sha1-XM50B7r2Qsunvs2laBEcST9ZZlo="
-        }
-      }
-    },
-    "aligned-block-file": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/aligned-block-file/-/aligned-block-file-1.1.2.tgz",
-      "integrity": "sha1-SpFo1f7+Xi9SWUncVaSqCZA7MtQ=",
-      "requires": {
-        "hashlru": "2.2.1",
-        "int53": "0.2.4",
-        "mkdirp": "0.5.1",
-        "obv": "0.0.0",
-        "uint48be": "1.0.2"
-      },
-      "dependencies": {
-        "obv": {
-          "version": "0.0.0",
-          "resolved": "https://registry.npmjs.org/obv/-/obv-0.0.0.tgz",
-          "integrity": "sha1-7eq4Ro+R1BkzYu1/kdC5bdOaecE="
-        }
-      }
-    },
-    "ansi-escapes": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
-      "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4="
-    },
-    "ansi-regex": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-    },
-    "ansi-styles": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-    },
-    "anymatch": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
-      "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
-      "requires": {
-        "micromatch": "2.3.11",
-        "normalize-path": "2.1.1"
-      }
-    },
-    "append-batch": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/append-batch/-/append-batch-0.0.1.tgz",
-      "integrity": "sha1-kiSFjlVpl8zAfxHx7poShTKqDSU="
-    },
-    "aproba": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
-    },
-    "are-we-there-yet": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
-      "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
-      "requires": {
-        "delegates": "1.0.0",
-        "readable-stream": "2.3.3"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-        },
-        "readable-stream": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
-          }
-        },
-        "string_decoder": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
-        }
-      }
-    },
-    "arr-diff": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-      "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-      "requires": {
-        "arr-flatten": "1.1.0"
-      }
-    },
-    "arr-flatten": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
-    },
-    "array-union": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
-      "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
-      "requires": {
-        "array-uniq": "1.0.3"
-      }
-    },
-    "array-uniq": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
-      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY="
-    },
-    "array-unique": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-      "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
-    },
-    "arraybuffer-base64": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/arraybuffer-base64/-/arraybuffer-base64-1.0.0.tgz",
-      "integrity": "sha1-/QIXuiuo1IYzZj+kOoCTdoAp2jA="
-    },
-    "arrify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
-    },
-    "async-each": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
-      "integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0="
-    },
     "async-single": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/async-single/-/async-single-1.0.5.tgz",
-      "integrity": "sha1-El3QneldPqMKN4rb7QIQkhebA8k="
-    },
-    "async-write": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/async-write/-/async-write-2.1.0.tgz",
-      "integrity": "sha1-HnYoF9hJzkS/rAeSWkIDZ4cGGxU="
+      "integrity": "sha1-El3QneldPqMKN4rb7QIQkhebA8k=",
+      "dev": true
     },
     "atomic-file": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/atomic-file/-/atomic-file-0.0.1.tgz",
-      "integrity": "sha1-bDZlj2xOzjP7o4d3MefCX8gpmbs="
-    },
-    "attach-ware": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/attach-ware/-/attach-ware-1.1.1.tgz",
-      "integrity": "sha1-KPUTk92LuL2q2XI0JRm/CWIaNaM=",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/atomic-file/-/atomic-file-2.0.1.tgz",
+      "integrity": "sha512-9JCWojeLDF8UhEv2UJlLlPGsLEs+EBnfB+kOhsvmFI2QilVrnIsAwr7YnF8lLEVuxB+HxFhvGK+ax0Y8Eh/BKA==",
+      "dev": true,
       "requires": {
-        "unherit": "1.1.0"
+        "flumecodec": "0.0.1",
+        "idb-kv-store": "^4.4.0"
+      },
+      "dependencies": {
+        "flumecodec": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/flumecodec/-/flumecodec-0.0.1.tgz",
+          "integrity": "sha1-rgSacUOGu4PjQmV6gpJLcDZKkNY=",
+          "dev": true,
+          "requires": {
+            "level-codec": "^6.2.0"
+          }
+        }
       }
-    },
-    "bail": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/bail/-/bail-1.0.2.tgz",
-      "integrity": "sha1-99bBcxYwqfnw1NNe0fli4gdKF2Q="
     },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
-    "bash-color": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/bash-color/-/bash-color-0.0.4.tgz",
-      "integrity": "sha1-6b6M4zVAytpIgXaMWb1jhlc26RM="
-    },
-    "binary-extensions": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz",
-      "integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU="
-    },
-    "binary-search": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/binary-search/-/binary-search-1.3.2.tgz",
-      "integrity": "sha1-iMm3vStyIdNS2njsiH9a8lSeTeI="
-    },
-    "binary-xhr": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/binary-xhr/-/binary-xhr-0.0.2.tgz",
-      "integrity": "sha1-IQywda0XeqRIpu+iiMEKiZw7OYc=",
-      "requires": {
-        "inherits": "1.0.0"
-      },
-      "dependencies": {
-        "inherits": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz",
-          "integrity": "sha1-OOGXUoW/H3upyE2hArsSdxMirEg="
-        }
-      }
-    },
-    "bindings": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz",
-      "integrity": "sha1-FK1hE4EtLTfXLme0ystLtyZQXxE="
-    },
-    "bl": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-0.8.2.tgz",
-      "integrity": "sha1-yba8oI0bwuoA/Ir7Txpf0eHGbk4=",
-      "requires": {
-        "readable-stream": "1.0.34"
-      }
-    },
-    "blake2s": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/blake2s/-/blake2s-1.0.1.tgz",
-      "integrity": "sha1-FZiCKjIOzmqkAbqYKVT4L2GwzXs="
-    },
     "brace-expansion": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
       "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
-    "braces": {
-      "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-      "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-      "requires": {
-        "expand-range": "1.8.2",
-        "preserve": "0.2.0",
-        "repeat-element": "1.1.2"
-      }
-    },
-    "broadcast-stream": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/broadcast-stream/-/broadcast-stream-0.2.2.tgz",
-      "integrity": "sha1-eee7FKmrunf3KsklgiAkKo/TkZ0="
-    },
-    "browser-split": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/browser-split/-/browser-split-0.0.0.tgz",
-      "integrity": "sha1-QUGcrvdpdVkp3VGJZ9PuwKYmJ3E="
-    },
-    "bytewise": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/bytewise/-/bytewise-1.1.0.tgz",
-      "integrity": "sha1-HRPL/3F65xWAlKqIGzXQgbOHJT4=",
-      "requires": {
-        "bytewise-core": "1.2.3",
-        "typewise": "1.0.3"
-      }
-    },
-    "bytewise-core": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/bytewise-core/-/bytewise-core-1.2.3.tgz",
-      "integrity": "sha1-P7QQx+kVWOsasiqCg0V3qmvWHUI=",
-      "requires": {
-        "typewise-core": "1.2.0"
-      }
-    },
-    "camelcase": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-      "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
-    },
-    "ccount": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/ccount/-/ccount-1.0.2.tgz",
-      "integrity": "sha1-U7ai+BW7d7nChx97mnLDol8djok="
-    },
-    "chalk": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-      "requires": {
-        "ansi-styles": "2.2.1",
-        "escape-string-regexp": "1.0.5",
-        "has-ansi": "2.0.0",
-        "strip-ansi": "3.0.1",
-        "supports-color": "2.0.0"
-      }
-    },
-    "character-entities": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.1.tgz",
-      "integrity": "sha1-92hxvl72bdt/j440eOzDdMJ9bco="
-    },
-    "character-entities-html4": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-1.1.1.tgz",
-      "integrity": "sha1-NZoqSg9+KdPcKsmb2+Ie45Q46lA="
-    },
-    "character-entities-legacy": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.1.tgz",
-      "integrity": "sha1-9Ad53xoQGHK7UQo9KV4fzPFHIC8="
-    },
-    "character-reference-invalid": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.1.tgz",
-      "integrity": "sha1-lCg191Dk7GGjCOYMLvjMEBEgLvw="
-    },
     "chloride": {
-      "version": "2.2.8",
-      "resolved": "https://registry.npmjs.org/chloride/-/chloride-2.2.8.tgz",
-      "integrity": "sha1-6/mos8qJp0R8NgOW2t+BfIqY1Zk=",
+      "version": "2.2.14",
+      "resolved": "https://registry.npmjs.org/chloride/-/chloride-2.2.14.tgz",
+      "integrity": "sha512-Jp3kpDIO4MlcJCFi4jER9P7k3sAVvIwbe4QJtM9Nkp43e/GQ/98HU1wJS6NdU6cbzfGrKWmMdRB+VNRrCynzfw==",
       "requires": {
-        "is-electron": "2.1.0",
-        "sodium-browserify": "1.2.1",
-        "sodium-browserify-tweetnacl": "0.2.3",
-        "sodium-chloride": "1.1.0",
-        "sodium-native": "2.1.4"
+        "is-electron": "^2.2.0",
+        "sodium-browserify": "^1.2.7",
+        "sodium-browserify-tweetnacl": "^0.2.5",
+        "sodium-chloride": "^1.1.2",
+        "sodium-native": "^2.1.6"
       }
     },
     "chloride-test": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/chloride-test/-/chloride-test-1.2.2.tgz",
-      "integrity": "sha1-F4aGqF6SeARREulujHkXk/mhCuo=",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/chloride-test/-/chloride-test-1.2.4.tgz",
+      "integrity": "sha512-9vhoi1qXSBPn6//ZxIgSe3M2QhKHzIPZQzmrZgmPADsqW0Jxpe3db1e7aGSRUMXbxAQ04SfypdT8dGaSvIvKDw==",
       "requires": {
-        "json-buffer": "2.0.11"
+        "json-buffer": "^2.0.11"
       }
-    },
-    "chokidar": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
-      "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
-      "requires": {
-        "anymatch": "1.3.2",
-        "async-each": "1.0.1",
-        "fsevents": "1.1.3",
-        "glob-parent": "2.0.0",
-        "inherits": "2.0.3",
-        "is-binary-path": "1.0.1",
-        "is-glob": "2.0.1",
-        "path-is-absolute": "1.0.1",
-        "readdirp": "2.1.0"
-      }
-    },
-    "chownr": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
-      "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE="
-    },
-    "class-list": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/class-list/-/class-list-0.1.1.tgz",
-      "integrity": "sha1-m5dFGSxBebXaCg12M2WOPHDXlss=",
-      "requires": {
-        "indexof": "0.0.1"
-      }
-    },
-    "cli-cursor": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
-      "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
-      "requires": {
-        "restore-cursor": "1.0.1"
-      }
-    },
-    "co": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/co/-/co-3.1.0.tgz",
-      "integrity": "sha1-TqVOpaCJOBUxheFSEMaNkJK8G3g="
-    },
-    "code-point-at": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
-    },
-    "collapse-white-space": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-1.0.3.tgz",
-      "integrity": "sha1-S5BvZw5aljqHt2sOFolkM0G2Ajw="
     },
     "commander": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.13.0.tgz",
-      "integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA=="
+      "version": "2.20.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
+      "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
+      "dev": true
     },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
-    "concat-stream": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
-      "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
-      "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.3",
-        "typedarray": "0.0.6"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-        },
-        "readable-stream": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
-          }
-        },
-        "string_decoder": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
-        }
-      }
-    },
-    "console-control-strings": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
-    },
-    "cont": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/cont/-/cont-1.0.3.tgz",
-      "integrity": "sha1-aHTx6TX8qZ0EjK6qrZoK6wILzOA=",
-      "requires": {
-        "continuable": "1.2.0",
-        "continuable-para": "1.2.0",
-        "continuable-series": "1.2.0"
-      }
-    },
-    "continuable": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/continuable/-/continuable-1.2.0.tgz",
-      "integrity": "sha1-CCd0aNQRNiAAdMz4cpQwjRafJbY="
-    },
-    "continuable-hash": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/continuable-hash/-/continuable-hash-0.1.4.tgz",
-      "integrity": "sha1-gcdNQXcdjJJ4Ph4A5fEbNNbfx4w=",
-      "requires": {
-        "continuable": "1.1.8"
-      },
-      "dependencies": {
-        "continuable": {
-          "version": "1.1.8",
-          "resolved": "https://registry.npmjs.org/continuable/-/continuable-1.1.8.tgz",
-          "integrity": "sha1-3Id7R0FghwrjvN6HM2Jo6+UFl9U="
-        }
-      }
-    },
-    "continuable-list": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/continuable-list/-/continuable-list-0.1.6.tgz",
-      "integrity": "sha1-h88G7FgHFuEN/5X7C4TF8OisrF8=",
-      "requires": {
-        "continuable": "1.1.8"
-      },
-      "dependencies": {
-        "continuable": {
-          "version": "1.1.8",
-          "resolved": "https://registry.npmjs.org/continuable/-/continuable-1.1.8.tgz",
-          "integrity": "sha1-3Id7R0FghwrjvN6HM2Jo6+UFl9U="
-        }
-      }
-    },
-    "continuable-para": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/continuable-para/-/continuable-para-1.2.0.tgz",
-      "integrity": "sha1-RFUQ9klFndD8NchyAVFGEicxxYM=",
-      "requires": {
-        "continuable-hash": "0.1.4",
-        "continuable-list": "0.1.6"
-      }
-    },
-    "continuable-series": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/continuable-series/-/continuable-series-1.2.0.tgz",
-      "integrity": "sha1-MkM5euk6cdZVswJoNKUVkLlYueg="
-    },
-    "core-util-is": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
-    },
-    "cross-spawn": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-      "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
-      "requires": {
-        "lru-cache": "4.1.1",
-        "shebang-command": "1.2.0",
-        "which": "1.3.0"
-      }
-    },
-    "debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "requires": {
-        "ms": "2.0.0"
-      }
-    },
     "deep-equal": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
-      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU="
-    },
-    "deep-extend": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
-      "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8="
-    },
-    "deferred-leveldown": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-0.2.0.tgz",
-      "integrity": "sha1-LO8fER4cV4cNi7uK8mUOWHzS9bQ=",
-      "requires": {
-        "abstract-leveldown": "0.12.4"
-      }
+      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
+      "dev": true
     },
     "define-properties": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
-      "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
       "dev": true,
       "requires": {
-        "foreach": "2.0.5",
-        "object-keys": "1.0.11"
+        "object-keys": "^1.0.12"
       }
     },
     "defined": {
@@ -567,1128 +97,82 @@
       "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
       "dev": true
     },
-    "delegates": {
+    "discontinuous-range": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
-    },
-    "detab": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/detab/-/detab-1.0.2.tgz",
-      "integrity": "sha1-AbwqSr57x8xnwwOYCO265HBJoO4=",
-      "requires": {
-        "repeat-string": "1.6.1"
-      }
-    },
-    "detect-libc": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-      "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups="
+      "resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
+      "integrity": "sha1-44Mx8IRLukm5qctxx3FYWqsbxlo=",
+      "dev": true
     },
     "ed2curve": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/ed2curve/-/ed2curve-0.1.4.tgz",
       "integrity": "sha1-lKRCSLuH2jXbDv968KpXYWgRf1k=",
       "requires": {
-        "tweetnacl": "0.14.5"
-      }
-    },
-    "elegant-spinner": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/elegant-spinner/-/elegant-spinner-1.0.1.tgz",
-      "integrity": "sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4="
-    },
-    "emoji-named-characters": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/emoji-named-characters/-/emoji-named-characters-1.0.2.tgz",
-      "integrity": "sha1-zes20OZgAsS5178d+8Ohmft9QJs="
-    },
-    "emoji-server": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-server/-/emoji-server-1.0.0.tgz",
-      "integrity": "sha1-0GPP7prxGMxa7vvC6bPdUIWBXGM=",
-      "requires": {
-        "emoji-named-characters": "1.0.2"
-      }
-    },
-    "end-of-stream": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
-      "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
-      "requires": {
-        "once": "1.4.0"
-      }
-    },
-    "errno": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.6.tgz",
-      "integrity": "sha512-IsORQDpaaSwcDP4ZZnHxgE85werpo34VYn1Ud3mq+eUsF593faR8oCZNXrROVkpFu2TsbrNhHin0aUrTsQ9vNw==",
-      "requires": {
-        "prr": "1.0.1"
-      },
-      "dependencies": {
-        "prr": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
-          "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY="
-        }
+        "tweetnacl": "0.x.x"
       }
     },
     "es-abstract": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.10.0.tgz",
-      "integrity": "sha512-/uh/DhdqIOSkAWifU+8nG78vlQxdLckUdI/sPgy0VhuXi2qJ7T8czBmqIYtLQVpCIFYafChnsRsB5pyb1JdmCQ==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.13.0.tgz",
+      "integrity": "sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==",
       "dev": true,
       "requires": {
-        "es-to-primitive": "1.1.1",
-        "function-bind": "1.1.1",
-        "has": "1.0.1",
-        "is-callable": "1.1.3",
-        "is-regex": "1.0.4"
+        "es-to-primitive": "^1.2.0",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "is-callable": "^1.1.4",
+        "is-regex": "^1.0.4",
+        "object-keys": "^1.0.12"
       }
     },
     "es-to-primitive": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
-      "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
+      "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
       "dev": true,
       "requires": {
-        "is-callable": "1.1.3",
-        "is-date-object": "1.0.1",
-        "is-symbol": "1.0.1"
-      }
-    },
-    "escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
-    },
-    "exit-hook": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
-      "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g="
-    },
-    "expand-brackets": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-      "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-      "requires": {
-        "is-posix-bracket": "0.1.1"
-      }
-    },
-    "expand-range": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
-      "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
-      "requires": {
-        "fill-range": "2.2.3"
-      }
-    },
-    "expand-template": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-1.1.0.tgz",
-      "integrity": "sha512-kkjwkMqj0h4w/sb32ERCDxCQkREMCAgS39DscDnSwDsbxnwwM1BTZySdC3Bn1lhY7vL08n9GoO/fVTynjDgRyQ=="
-    },
-    "explain-error": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/explain-error/-/explain-error-1.0.4.tgz",
-      "integrity": "sha1-p5PTrAytTGq1cemWj7urbLJTKSk="
-    },
-    "extend": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
-    },
-    "extend.js": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/extend.js/-/extend.js-0.0.2.tgz",
-      "integrity": "sha1-D5x6gaHyCLcD6wwxMf5XFqxuzRU="
-    },
-    "extglob": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-      "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-      "requires": {
-        "is-extglob": "1.0.0"
-      }
-    },
-    "fast-future": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/fast-future/-/fast-future-1.0.2.tgz",
-      "integrity": "sha1-hDWpqqAteSSNF9cE52JZMB2ZKAo="
-    },
-    "filename-regex": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
-      "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY="
-    },
-    "fill-range": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
-      "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
-      "requires": {
-        "is-number": "2.1.0",
-        "isobject": "2.1.0",
-        "randomatic": "1.1.7",
-        "repeat-element": "1.1.2",
-        "repeat-string": "1.6.1"
+        "is-callable": "^1.1.4",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.2"
       }
     },
     "flumecodec": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/flumecodec/-/flumecodec-0.0.0.tgz",
       "integrity": "sha1-Ns4Gq+Lg4BxE3WnyoWUwWiMgZJs=",
+      "dev": true,
       "requires": {
-        "level-codec": "6.2.0"
-      }
-    },
-    "flumedb": {
-      "version": "0.4.6",
-      "resolved": "https://registry.npmjs.org/flumedb/-/flumedb-0.4.6.tgz",
-      "integrity": "sha1-wa/6cpXDZy5VF06yR5Uvl2aRfo8=",
-      "requires": {
-        "cont": "1.0.3",
-        "explain-error": "1.0.4",
-        "obv": "0.0.1",
-        "pull-cont": "0.0.0",
-        "pull-looper": "1.0.0",
-        "pull-stream": "3.6.1"
-      }
-    },
-    "flumelog-offset": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/flumelog-offset/-/flumelog-offset-3.2.6.tgz",
-      "integrity": "sha512-hE0vWDqFMjMhXROWEqEb9OFr6VFSjB8lvu4hgeQO9WxI9OqKVl0TD48Mf3NeTKrtXqHyxkfzQwMSw6fgKKf1lA==",
-      "requires": {
-        "aligned-block-file": "1.1.2",
-        "append-batch": "0.0.1",
-        "explain-error": "1.0.4",
-        "hashlru": "2.2.1",
-        "int53": "0.2.4",
-        "looper": "4.0.0",
-        "ltgt": "2.2.0",
-        "obv": "0.0.1",
-        "pull-cursor": "2.1.3",
-        "pull-looper": "1.0.0",
-        "uint48be": "1.0.2"
-      }
-    },
-    "flumeview-hashtable": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/flumeview-hashtable/-/flumeview-hashtable-1.0.3.tgz",
-      "integrity": "sha1-0qn6Fkn1fvaNG4nrTEO/sXJDeWc=",
-      "requires": {
-        "async-single": "1.0.5",
-        "atomic-file": "1.1.4",
-        "obv": "0.0.1",
-        "pull-stream": "3.6.1"
-      },
-      "dependencies": {
-        "atomic-file": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/atomic-file/-/atomic-file-1.1.4.tgz",
-          "integrity": "sha1-ZhUuOfzosrDH5fJi4KGl06s6q1E="
-        }
-      }
-    },
-    "flumeview-level": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/flumeview-level/-/flumeview-level-2.1.1.tgz",
-      "integrity": "sha1-KQkSRgKzKdT2oOuMkDigyRFrNoE=",
-      "requires": {
-        "bytewise": "1.1.0",
-        "explain-error": "1.0.4",
-        "level": "1.7.0",
-        "ltgt": "2.2.0",
-        "mkdirp": "0.5.1",
-        "obv": "0.0.0",
-        "pull-level": "2.0.3",
-        "pull-paramap": "1.2.2",
-        "pull-stream": "3.6.1",
-        "pull-write": "1.1.4"
-      },
-      "dependencies": {
-        "obv": {
-          "version": "0.0.0",
-          "resolved": "https://registry.npmjs.org/obv/-/obv-0.0.0.tgz",
-          "integrity": "sha1-7eq4Ro+R1BkzYu1/kdC5bdOaecE="
-        }
-      }
-    },
-    "flumeview-query": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/flumeview-query/-/flumeview-query-4.0.1.tgz",
-      "integrity": "sha1-HNTf2S8acBKN2dgN3qqdRJVuzO0=",
-      "requires": {
-        "explain-error": "1.0.4",
-        "flumeview-level": "2.1.1",
-        "map-filter-reduce": "3.0.3",
-        "pull-flatmap": "0.0.1",
-        "pull-paramap": "1.2.2",
-        "pull-sink-through": "0.0.0",
-        "pull-stream": "3.6.1"
-      },
-      "dependencies": {
-        "map-filter-reduce": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/map-filter-reduce/-/map-filter-reduce-3.0.3.tgz",
-          "integrity": "sha1-ihC4bjRlut13YBqZV9velLmNYKo=",
-          "requires": {
-            "binary-search": "1.3.2",
-            "pull-sink-through": "0.0.0",
-            "pull-stream": "3.6.1",
-            "typewiselite": "1.0.0"
-          }
-        }
+        "level-codec": "^6.2.0"
       }
     },
     "flumeview-reduce": {
-      "version": "1.3.12",
-      "resolved": "https://registry.npmjs.org/flumeview-reduce/-/flumeview-reduce-1.3.12.tgz",
-      "integrity": "sha1-3eiAMca85rox1DgpGWN4iLzAyqE=",
+      "version": "1.3.16",
+      "resolved": "https://registry.npmjs.org/flumeview-reduce/-/flumeview-reduce-1.3.16.tgz",
+      "integrity": "sha512-4ATidV3QARML74eNdi+HPzGa4JtSZfnQpW6QQArlKZ6NRkjax3EFLt42hK2VJyADxnVnsVInt/ItqJL/4G1/5g==",
+      "dev": true,
       "requires": {
-        "async-single": "1.0.5",
-        "atomic-file": "1.1.4",
-        "deep-equal": "1.0.1",
+        "async-single": "^1.0.5",
+        "atomic-file": "^2.0.0",
+        "deep-equal": "^1.0.1",
         "flumecodec": "0.0.0",
-        "obv": "0.0.0",
-        "pull-notify": "0.1.1",
-        "pull-stream": "3.6.1"
-      },
-      "dependencies": {
-        "atomic-file": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/atomic-file/-/atomic-file-1.1.4.tgz",
-          "integrity": "sha1-ZhUuOfzosrDH5fJi4KGl06s6q1E="
-        },
-        "obv": {
-          "version": "0.0.0",
-          "resolved": "https://registry.npmjs.org/obv/-/obv-0.0.0.tgz",
-          "integrity": "sha1-7eq4Ro+R1BkzYu1/kdC5bdOaecE="
-        }
+        "obv": "0.0.1",
+        "pull-notify": "^0.1.1",
+        "pull-stream": "^3.5.0"
       }
     },
     "for-each": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.2.tgz",
-      "integrity": "sha1-LEBFC5NI6X8oEyJZO6lnBLmr1NQ=",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
+      "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
       "dev": true,
       "requires": {
-        "is-function": "1.0.1"
+        "is-callable": "^1.1.3"
       }
-    },
-    "for-in": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
-      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
-    },
-    "for-own": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
-      "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
-      "requires": {
-        "for-in": "1.0.2"
-      }
-    },
-    "foreach": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
-      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
-      "dev": true
     },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
-    },
-    "fsevents": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.3.tgz",
-      "integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
-      "optional": true,
-      "requires": {
-        "nan": "2.8.0",
-        "node-pre-gyp": "0.6.39"
-      },
-      "dependencies": {
-        "abbrev": {
-          "version": "1.1.0",
-          "bundled": true,
-          "optional": true
-        },
-        "ajv": {
-          "version": "4.11.8",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "co": "4.6.0",
-            "json-stable-stringify": "1.0.1"
-          }
-        },
-        "ansi-regex": {
-          "version": "2.1.1",
-          "bundled": true
-        },
-        "aproba": {
-          "version": "1.1.1",
-          "bundled": true,
-          "optional": true
-        },
-        "are-we-there-yet": {
-          "version": "1.1.4",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "delegates": "1.0.0",
-            "readable-stream": "2.2.9"
-          }
-        },
-        "asn1": {
-          "version": "0.2.3",
-          "bundled": true,
-          "optional": true
-        },
-        "assert-plus": {
-          "version": "0.2.0",
-          "bundled": true,
-          "optional": true
-        },
-        "asynckit": {
-          "version": "0.4.0",
-          "bundled": true,
-          "optional": true
-        },
-        "aws-sign2": {
-          "version": "0.6.0",
-          "bundled": true,
-          "optional": true
-        },
-        "aws4": {
-          "version": "1.6.0",
-          "bundled": true,
-          "optional": true
-        },
-        "balanced-match": {
-          "version": "0.4.2",
-          "bundled": true
-        },
-        "bcrypt-pbkdf": {
-          "version": "1.0.1",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "tweetnacl": "0.14.5"
-          }
-        },
-        "block-stream": {
-          "version": "0.0.9",
-          "bundled": true,
-          "requires": {
-            "inherits": "2.0.3"
-          }
-        },
-        "boom": {
-          "version": "2.10.1",
-          "bundled": true,
-          "requires": {
-            "hoek": "2.16.3"
-          }
-        },
-        "brace-expansion": {
-          "version": "1.1.7",
-          "bundled": true,
-          "requires": {
-            "balanced-match": "0.4.2",
-            "concat-map": "0.0.1"
-          }
-        },
-        "buffer-shims": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "caseless": {
-          "version": "0.12.0",
-          "bundled": true,
-          "optional": true
-        },
-        "co": {
-          "version": "4.6.0",
-          "bundled": true,
-          "optional": true
-        },
-        "code-point-at": {
-          "version": "1.1.0",
-          "bundled": true
-        },
-        "combined-stream": {
-          "version": "1.0.5",
-          "bundled": true,
-          "requires": {
-            "delayed-stream": "1.0.0"
-          }
-        },
-        "concat-map": {
-          "version": "0.0.1",
-          "bundled": true
-        },
-        "console-control-strings": {
-          "version": "1.1.0",
-          "bundled": true
-        },
-        "core-util-is": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "cryptiles": {
-          "version": "2.0.5",
-          "bundled": true,
-          "requires": {
-            "boom": "2.10.1"
-          }
-        },
-        "dashdash": {
-          "version": "1.14.1",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "assert-plus": "1.0.0"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true,
-              "optional": true
-            }
-          }
-        },
-        "debug": {
-          "version": "2.6.8",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "deep-extend": {
-          "version": "0.4.2",
-          "bundled": true,
-          "optional": true
-        },
-        "delayed-stream": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "delegates": {
-          "version": "1.0.0",
-          "bundled": true,
-          "optional": true
-        },
-        "detect-libc": {
-          "version": "1.0.2",
-          "bundled": true,
-          "optional": true
-        },
-        "ecc-jsbn": {
-          "version": "0.1.1",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "jsbn": "0.1.1"
-          }
-        },
-        "extend": {
-          "version": "3.0.1",
-          "bundled": true,
-          "optional": true
-        },
-        "extsprintf": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "forever-agent": {
-          "version": "0.6.1",
-          "bundled": true,
-          "optional": true
-        },
-        "form-data": {
-          "version": "2.1.4",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "asynckit": "0.4.0",
-            "combined-stream": "1.0.5",
-            "mime-types": "2.1.15"
-          }
-        },
-        "fs.realpath": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "fstream": {
-          "version": "1.0.11",
-          "bundled": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "inherits": "2.0.3",
-            "mkdirp": "0.5.1",
-            "rimraf": "2.6.1"
-          }
-        },
-        "fstream-ignore": {
-          "version": "1.0.5",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "fstream": "1.0.11",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4"
-          }
-        },
-        "gauge": {
-          "version": "2.7.4",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "aproba": "1.1.1",
-            "console-control-strings": "1.1.0",
-            "has-unicode": "2.0.1",
-            "object-assign": "4.1.1",
-            "signal-exit": "3.0.2",
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wide-align": "1.1.2"
-          }
-        },
-        "getpass": {
-          "version": "0.1.7",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "assert-plus": "1.0.0"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true,
-              "optional": true
-            }
-          }
-        },
-        "glob": {
-          "version": "7.1.2",
-          "bundled": true,
-          "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          }
-        },
-        "graceful-fs": {
-          "version": "4.1.11",
-          "bundled": true
-        },
-        "har-schema": {
-          "version": "1.0.5",
-          "bundled": true,
-          "optional": true
-        },
-        "har-validator": {
-          "version": "4.2.1",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "ajv": "4.11.8",
-            "har-schema": "1.0.5"
-          }
-        },
-        "has-unicode": {
-          "version": "2.0.1",
-          "bundled": true,
-          "optional": true
-        },
-        "hawk": {
-          "version": "3.1.3",
-          "bundled": true,
-          "requires": {
-            "boom": "2.10.1",
-            "cryptiles": "2.0.5",
-            "hoek": "2.16.3",
-            "sntp": "1.0.9"
-          }
-        },
-        "hoek": {
-          "version": "2.16.3",
-          "bundled": true
-        },
-        "http-signature": {
-          "version": "1.1.1",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "assert-plus": "0.2.0",
-            "jsprim": "1.4.0",
-            "sshpk": "1.13.0"
-          }
-        },
-        "inflight": {
-          "version": "1.0.6",
-          "bundled": true,
-          "requires": {
-            "once": "1.4.0",
-            "wrappy": "1.0.2"
-          }
-        },
-        "inherits": {
-          "version": "2.0.3",
-          "bundled": true
-        },
-        "ini": {
-          "version": "1.3.4",
-          "bundled": true,
-          "optional": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "bundled": true,
-          "requires": {
-            "number-is-nan": "1.0.1"
-          }
-        },
-        "is-typedarray": {
-          "version": "1.0.0",
-          "bundled": true,
-          "optional": true
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "isstream": {
-          "version": "0.1.2",
-          "bundled": true,
-          "optional": true
-        },
-        "jodid25519": {
-          "version": "1.0.2",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "jsbn": "0.1.1"
-          }
-        },
-        "jsbn": {
-          "version": "0.1.1",
-          "bundled": true,
-          "optional": true
-        },
-        "json-schema": {
-          "version": "0.2.3",
-          "bundled": true,
-          "optional": true
-        },
-        "json-stable-stringify": {
-          "version": "1.0.1",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "jsonify": "0.0.0"
-          }
-        },
-        "json-stringify-safe": {
-          "version": "5.0.1",
-          "bundled": true,
-          "optional": true
-        },
-        "jsonify": {
-          "version": "0.0.0",
-          "bundled": true,
-          "optional": true
-        },
-        "jsprim": {
-          "version": "1.4.0",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "assert-plus": "1.0.0",
-            "extsprintf": "1.0.2",
-            "json-schema": "0.2.3",
-            "verror": "1.3.6"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true,
-              "optional": true
-            }
-          }
-        },
-        "mime-db": {
-          "version": "1.27.0",
-          "bundled": true
-        },
-        "mime-types": {
-          "version": "2.1.15",
-          "bundled": true,
-          "requires": {
-            "mime-db": "1.27.0"
-          }
-        },
-        "minimatch": {
-          "version": "3.0.4",
-          "bundled": true,
-          "requires": {
-            "brace-expansion": "1.1.7"
-          }
-        },
-        "minimist": {
-          "version": "0.0.8",
-          "bundled": true
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "bundled": true,
-          "requires": {
-            "minimist": "0.0.8"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "bundled": true,
-          "optional": true
-        },
-        "node-pre-gyp": {
-          "version": "0.6.39",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "detect-libc": "1.0.2",
-            "hawk": "3.1.3",
-            "mkdirp": "0.5.1",
-            "nopt": "4.0.1",
-            "npmlog": "4.1.0",
-            "rc": "1.2.1",
-            "request": "2.81.0",
-            "rimraf": "2.6.1",
-            "semver": "5.3.0",
-            "tar": "2.2.1",
-            "tar-pack": "3.4.0"
-          }
-        },
-        "nopt": {
-          "version": "4.0.1",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "abbrev": "1.1.0",
-            "osenv": "0.1.4"
-          }
-        },
-        "npmlog": {
-          "version": "4.1.0",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "are-we-there-yet": "1.1.4",
-            "console-control-strings": "1.1.0",
-            "gauge": "2.7.4",
-            "set-blocking": "2.0.0"
-          }
-        },
-        "number-is-nan": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "oauth-sign": {
-          "version": "0.8.2",
-          "bundled": true,
-          "optional": true
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "bundled": true,
-          "optional": true
-        },
-        "once": {
-          "version": "1.4.0",
-          "bundled": true,
-          "requires": {
-            "wrappy": "1.0.2"
-          }
-        },
-        "os-homedir": {
-          "version": "1.0.2",
-          "bundled": true,
-          "optional": true
-        },
-        "os-tmpdir": {
-          "version": "1.0.2",
-          "bundled": true,
-          "optional": true
-        },
-        "osenv": {
-          "version": "0.1.4",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "os-homedir": "1.0.2",
-            "os-tmpdir": "1.0.2"
-          }
-        },
-        "path-is-absolute": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "performance-now": {
-          "version": "0.2.0",
-          "bundled": true,
-          "optional": true
-        },
-        "process-nextick-args": {
-          "version": "1.0.7",
-          "bundled": true
-        },
-        "punycode": {
-          "version": "1.4.1",
-          "bundled": true,
-          "optional": true
-        },
-        "qs": {
-          "version": "6.4.0",
-          "bundled": true,
-          "optional": true
-        },
-        "rc": {
-          "version": "1.2.1",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "deep-extend": "0.4.2",
-            "ini": "1.3.4",
-            "minimist": "1.2.0",
-            "strip-json-comments": "2.0.1"
-          },
-          "dependencies": {
-            "minimist": {
-              "version": "1.2.0",
-              "bundled": true,
-              "optional": true
-            }
-          }
-        },
-        "readable-stream": {
-          "version": "2.2.9",
-          "bundled": true,
-          "requires": {
-            "buffer-shims": "1.0.0",
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "string_decoder": "1.0.1",
-            "util-deprecate": "1.0.2"
-          }
-        },
-        "request": {
-          "version": "2.81.0",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "aws-sign2": "0.6.0",
-            "aws4": "1.6.0",
-            "caseless": "0.12.0",
-            "combined-stream": "1.0.5",
-            "extend": "3.0.1",
-            "forever-agent": "0.6.1",
-            "form-data": "2.1.4",
-            "har-validator": "4.2.1",
-            "hawk": "3.1.3",
-            "http-signature": "1.1.1",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.15",
-            "oauth-sign": "0.8.2",
-            "performance-now": "0.2.0",
-            "qs": "6.4.0",
-            "safe-buffer": "5.0.1",
-            "stringstream": "0.0.5",
-            "tough-cookie": "2.3.2",
-            "tunnel-agent": "0.6.0",
-            "uuid": "3.0.1"
-          }
-        },
-        "rimraf": {
-          "version": "2.6.1",
-          "bundled": true,
-          "requires": {
-            "glob": "7.1.2"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.0.1",
-          "bundled": true
-        },
-        "semver": {
-          "version": "5.3.0",
-          "bundled": true,
-          "optional": true
-        },
-        "set-blocking": {
-          "version": "2.0.0",
-          "bundled": true,
-          "optional": true
-        },
-        "signal-exit": {
-          "version": "3.0.2",
-          "bundled": true,
-          "optional": true
-        },
-        "sntp": {
-          "version": "1.0.9",
-          "bundled": true,
-          "requires": {
-            "hoek": "2.16.3"
-          }
-        },
-        "sshpk": {
-          "version": "1.13.0",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "asn1": "0.2.3",
-            "assert-plus": "1.0.0",
-            "bcrypt-pbkdf": "1.0.1",
-            "dashdash": "1.14.1",
-            "ecc-jsbn": "0.1.1",
-            "getpass": "0.1.7",
-            "jodid25519": "1.0.2",
-            "jsbn": "0.1.1",
-            "tweetnacl": "0.14.5"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true,
-              "optional": true
-            }
-          }
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "bundled": true,
-          "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.0.1",
-          "bundled": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
-          }
-        },
-        "stringstream": {
-          "version": "0.0.5",
-          "bundled": true,
-          "optional": true
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "bundled": true,
-          "requires": {
-            "ansi-regex": "2.1.1"
-          }
-        },
-        "strip-json-comments": {
-          "version": "2.0.1",
-          "bundled": true,
-          "optional": true
-        },
-        "tar": {
-          "version": "2.2.1",
-          "bundled": true,
-          "requires": {
-            "block-stream": "0.0.9",
-            "fstream": "1.0.11",
-            "inherits": "2.0.3"
-          }
-        },
-        "tar-pack": {
-          "version": "3.4.0",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "debug": "2.6.8",
-            "fstream": "1.0.11",
-            "fstream-ignore": "1.0.5",
-            "once": "1.4.0",
-            "readable-stream": "2.2.9",
-            "rimraf": "2.6.1",
-            "tar": "2.2.1",
-            "uid-number": "0.0.6"
-          }
-        },
-        "tough-cookie": {
-          "version": "2.3.2",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "punycode": "1.4.1"
-          }
-        },
-        "tunnel-agent": {
-          "version": "0.6.0",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
-          }
-        },
-        "tweetnacl": {
-          "version": "0.14.5",
-          "bundled": true,
-          "optional": true
-        },
-        "uid-number": {
-          "version": "0.0.6",
-          "bundled": true,
-          "optional": true
-        },
-        "util-deprecate": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "uuid": {
-          "version": "3.0.1",
-          "bundled": true,
-          "optional": true
-        },
-        "verror": {
-          "version": "1.3.6",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "extsprintf": "1.0.2"
-          }
-        },
-        "wide-align": {
-          "version": "1.1.2",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "string-width": "1.0.2"
-          }
-        },
-        "wrappy": {
-          "version": "1.0.2",
-          "bundled": true
-        }
-      }
     },
     "function-bind": {
       "version": "1.1.1",
@@ -1696,171 +180,51 @@
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
       "dev": true
     },
-    "gauge": {
-      "version": "2.7.4",
-      "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-      "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
-      "requires": {
-        "aproba": "1.2.0",
-        "console-control-strings": "1.1.0",
-        "has-unicode": "2.0.1",
-        "object-assign": "4.1.1",
-        "signal-exit": "3.0.2",
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1",
-        "wide-align": "1.1.2"
-      }
-    },
-    "github-from-package": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
-      "integrity": "sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4="
-    },
     "glob": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
-      "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+      "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
       "requires": {
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
-      }
-    },
-    "glob-base": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
-      "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
-      "requires": {
-        "glob-parent": "2.0.0",
-        "is-glob": "2.0.1"
-      }
-    },
-    "glob-parent": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-      "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
-      "requires": {
-        "is-glob": "2.0.1"
-      }
-    },
-    "globby": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-4.1.0.tgz",
-      "integrity": "sha1-CA9UVJ7BuCpsYOYx/ILhIR2+lfg=",
-      "requires": {
-        "array-union": "1.0.2",
-        "arrify": "1.0.1",
-        "glob": "6.0.4",
-        "object-assign": "4.1.1",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1"
-      }
-    },
-    "graceful-fs": {
-      "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
-    },
-    "graphreduce": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/graphreduce/-/graphreduce-3.0.4.tgz",
-      "integrity": "sha1-v0QtCoeOg5AeXvPmUtI/+1uDHtc=",
-      "requires": {
-        "statistics": "3.3.0"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
     },
     "has": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
-      "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
       "dev": true,
       "requires": {
-        "function-bind": "1.1.1"
+        "function-bind": "^1.1.1"
       }
     },
-    "has-ansi": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+    "has-symbols": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
+      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
+      "dev": true
+    },
+    "idb-kv-store": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/idb-kv-store/-/idb-kv-store-4.4.0.tgz",
+      "integrity": "sha1-IsVqjV+QvYj4GKhZ25xYYn3ieL4=",
+      "dev": true,
       "requires": {
-        "ansi-regex": "2.1.1"
+        "inherits": "^2.0.3",
+        "promisize": "^1.1.2"
       }
-    },
-    "has-network": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/has-network/-/has-network-0.0.1.tgz",
-      "integrity": "sha1-Pup7RMqpYBeXEkvouonSKMQQFJk="
-    },
-    "has-unicode": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
-    },
-    "hashlru": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/hashlru/-/hashlru-2.2.1.tgz",
-      "integrity": "sha1-EPIJmg18BaQPK+r1wdOc8vfavzY="
-    },
-    "he": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/he/-/he-0.5.0.tgz",
-      "integrity": "sha1-LAX/rvkLaOhg8/0rVO9YCYknfuI="
-    },
-    "hoox": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/hoox/-/hoox-0.0.1.tgz",
-      "integrity": "sha1-CKdNknKpzIOujmu+AwPw7nZDIJQ="
-    },
-    "html-element": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/html-element/-/html-element-1.3.0.tgz",
-      "integrity": "sha1-117LXa6HSx3mCgv4eUu9GYTQ8gk=",
-      "requires": {
-        "class-list": "0.1.1"
-      }
-    },
-    "hyperfile": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/hyperfile/-/hyperfile-1.1.1.tgz",
-      "integrity": "sha1-czvGxmj7miFgCMTzNlMfiU28efM=",
-      "requires": {
-        "hyperscript": "1.4.7"
-      }
-    },
-    "hyperprogress": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/hyperprogress/-/hyperprogress-0.1.1.tgz",
-      "integrity": "sha1-5TDGFjqisSg+rBkhkiJadi8Jw0Q="
-    },
-    "hyperscript": {
-      "version": "1.4.7",
-      "resolved": "https://registry.npmjs.org/hyperscript/-/hyperscript-1.4.7.tgz",
-      "integrity": "sha1-HyPYgPhDbKrCW5GnrDl0e4mnJhg=",
-      "requires": {
-        "browser-split": "0.0.0",
-        "class-list": "0.1.1",
-        "html-element": "1.3.0"
-      }
-    },
-    "increment-buffer": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/increment-buffer/-/increment-buffer-1.0.1.tgz",
-      "integrity": "sha1-ZQdtdRidgIs5rROrW5WOBSFvng0="
-    },
-    "indexof": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
-      "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10="
     },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
@@ -1871,54 +235,25 @@
     "ini": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
-    },
-    "int53": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/int53/-/int53-0.2.4.tgz",
-      "integrity": "sha1-XtjXqtbFxlZ8rmmqf/xKEJ7oD4Y="
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+      "optional": true
     },
     "ip": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/ip/-/ip-0.3.3.tgz",
-      "integrity": "sha1-jugwnpLwsEDSh/cu+soaIXAtP7Q="
-    },
-    "irregular-plurals": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-1.4.0.tgz",
-      "integrity": "sha1-LKmwM2UREYVUEvFr5dd8YqRYp2Y="
-    },
-    "is-alphabetical": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.1.tgz",
-      "integrity": "sha1-x3B5zJHU76x3W+EDS/LSQ/lebwg="
-    },
-    "is-alphanumerical": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.1.tgz",
-      "integrity": "sha1-37SqTRCF4zvbYcLe6cgOnGwZ9Ts=",
-      "requires": {
-        "is-alphabetical": "1.0.1",
-        "is-decimal": "1.0.1"
-      }
-    },
-    "is-binary-path": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
-      "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
-      "requires": {
-        "binary-extensions": "1.11.0"
-      }
-    },
-    "is-buffer": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
+      "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
+      "dev": true
     },
     "is-callable": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
-      "integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI=",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
+      "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
+      "dev": true
+    },
+    "is-canonical-base64": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-canonical-base64/-/is-canonical-base64-1.1.1.tgz",
+      "integrity": "sha512-o6t/DwgEapC0bsloqtegAQyZzQXaQ5+8fzsyf2KmLqupC2ifLFq/lMQiFCJeGpdSrK1o6GL+WW2lRU050lLlFg==",
       "dev": true
     },
     "is-date-object": {
@@ -1927,83 +262,10 @@
       "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
       "dev": true
     },
-    "is-decimal": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.1.tgz",
-      "integrity": "sha1-9ftqlJlq2ejjdh+/vQkfH8qMToI="
-    },
-    "is-dotfile": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
-      "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE="
-    },
     "is-electron": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-electron/-/is-electron-2.1.0.tgz",
-      "integrity": "sha512-dkg5xT383+M6zIbbXW/z7n2nz4SFUi2OSyhntnFYkRdtV+HVEfdjEK+5AWisfYgkpe3WYjTIuh7toaKmSfFVWw=="
-    },
-    "is-equal-shallow": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
-      "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
-      "requires": {
-        "is-primitive": "2.0.0"
-      }
-    },
-    "is-extendable": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
-    },
-    "is-extglob": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-      "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
-    },
-    "is-fullwidth-code-point": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-      "requires": {
-        "number-is-nan": "1.0.1"
-      }
-    },
-    "is-function": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.1.tgz",
-      "integrity": "sha1-Es+5i2W1fdPRk6MSH19uL0N2ArU=",
-      "dev": true
-    },
-    "is-glob": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-      "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-      "requires": {
-        "is-extglob": "1.0.0"
-      }
-    },
-    "is-hexadecimal": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.1.tgz",
-      "integrity": "sha1-bghLvJIGH7sJcexYts5tQE4k2mk="
-    },
-    "is-number": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
-      "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
-      "requires": {
-        "kind-of": "3.2.2"
-      }
-    },
-    "is-posix-bracket": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
-      "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q="
-    },
-    "is-primitive": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-      "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-electron/-/is-electron-2.2.0.tgz",
+      "integrity": "sha512-SpMppC2XR3YdxSzczXReBjqs2zGscWQpBIKqwXYBFic0ERaxNVgwLCHwOLZeESfdJQjX0RDvrJ1lBXX2ij+G1Q=="
     },
     "is-regex": {
       "version": "1.0.4",
@@ -2011,418 +273,46 @@
       "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
       "dev": true,
       "requires": {
-        "has": "1.0.1"
+        "has": "^1.0.1"
       }
     },
     "is-symbol": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
-      "integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI=",
-      "dev": true
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
+      "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
+      "dev": true,
+      "requires": {
+        "has-symbols": "^1.0.0"
+      }
     },
     "is-valid-domain": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/is-valid-domain/-/is-valid-domain-0.0.5.tgz",
-      "integrity": "sha1-SOcDGfy0MAkjbpazf5hDiJzntRM="
-    },
-    "isarray": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-    },
-    "isexe": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
-    },
-    "isobject": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-      "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-      "requires": {
-        "isarray": "1.0.0"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-        }
-      }
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/is-valid-domain/-/is-valid-domain-0.0.11.tgz",
+      "integrity": "sha512-N+XmAifLwbpAf6d5GM5DliNOZZrq2wnmdsAuhM2gyVaKAoJQIBz4emiPC4cnh4cIGiIqg0QvAa7sCpvGkN4WCg==",
+      "dev": true
     },
     "json-buffer": {
       "version": "2.0.11",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-2.0.11.tgz",
       "integrity": "sha1-PkQf2jCYvo0eMXGtWRvGKjPi1V8="
     },
-    "kind-of": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-      "requires": {
-        "is-buffer": "1.1.6"
-      }
-    },
-    "level": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/level/-/level-1.7.0.tgz",
-      "integrity": "sha1-Q0ZKOounOy895WokKSgFFG2iE6E=",
-      "requires": {
-        "level-packager": "1.2.1",
-        "leveldown": "1.7.2"
-      }
-    },
     "level-codec": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-6.2.0.tgz",
-      "integrity": "sha1-pLUkS7akwvcj1oodZOmAxTYn2dQ="
-    },
-    "level-errors": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-1.0.5.tgz",
-      "integrity": "sha512-/cLUpQduF6bNrWuAC4pwtUKA5t669pCsCi2XbmojG2tFeOr9j6ShtdDCtFFQO1DRt+EVZhx9gPzP9G2bUaG4ig==",
-      "requires": {
-        "errno": "0.1.6"
-      }
-    },
-    "level-iterator-stream": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-1.3.1.tgz",
-      "integrity": "sha1-5Dt4sagUPm+pek9IXrjqUwNS8u0=",
-      "requires": {
-        "inherits": "2.0.3",
-        "level-errors": "1.0.5",
-        "readable-stream": "1.0.34",
-        "xtend": "4.0.1"
-      }
-    },
-    "level-live-stream": {
-      "version": "1.4.12",
-      "resolved": "https://registry.npmjs.org/level-live-stream/-/level-live-stream-1.4.12.tgz",
-      "integrity": "sha1-87jKj4n8Ec+y4P2rZJhOzs1aUhE=",
-      "requires": {
-        "level-sublevel": "6.6.1",
-        "pull-level": "2.0.3",
-        "pull-stream-to-stream": "1.2.6"
-      },
-      "dependencies": {
-        "pull-stream-to-stream": {
-          "version": "1.2.6",
-          "resolved": "https://registry.npmjs.org/pull-stream-to-stream/-/pull-stream-to-stream-1.2.6.tgz",
-          "integrity": "sha1-3Z+jcy7bPRbmfNHyJLyjim1XSMc=",
-          "requires": {
-            "pull-core": "1.1.0"
-          }
-        }
-      }
-    },
-    "level-memview": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/level-memview/-/level-memview-0.0.0.tgz",
-      "integrity": "sha1-RtNTc64040LPSldKXjUUodR1OiA=",
-      "requires": {
-        "level-live-stream": "1.4.12",
-        "pull-level": "1.2.0",
-        "pull-stream": "2.26.1"
-      },
-      "dependencies": {
-        "pull-core": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/pull-core/-/pull-core-1.0.0.tgz",
-          "integrity": "sha1-4OuTkY36cJY+0J429j2qFbdrOKQ="
-        },
-        "pull-level": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/pull-level/-/pull-level-1.2.0.tgz",
-          "integrity": "sha1-U7MhImUOsV01tg5UMh+6Ec9cbmY=",
-          "requires": {
-            "level-post": "1.0.5",
-            "pull-cat": "1.1.11",
-            "pull-pushable": "1.1.4",
-            "pull-stream": "2.26.1",
-            "pull-window": "2.1.4",
-            "stream-to-pull-stream": "1.3.1"
-          }
-        },
-        "pull-pushable": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/pull-pushable/-/pull-pushable-1.1.4.tgz",
-          "integrity": "sha1-dmTWdB9yaH71yJ9TO3hoLz3pog4=",
-          "requires": {
-            "pull-stream": "2.18.3"
-          },
-          "dependencies": {
-            "pull-stream": {
-              "version": "2.18.3",
-              "resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-2.18.3.tgz",
-              "integrity": "sha1-egeWIjTXV5yQiGDbjCf380/UUAA=",
-              "requires": {
-                "pull-core": "1.0.0"
-              }
-            }
-          }
-        },
-        "pull-stream": {
-          "version": "2.26.1",
-          "resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-2.26.1.tgz",
-          "integrity": "sha1-S/JVneh7ivL1uWtxkNLuQxyh5Rk=",
-          "requires": {
-            "pull-core": "1.1.0"
-          },
-          "dependencies": {
-            "pull-core": {
-              "version": "1.1.0",
-              "resolved": "https://registry.npmjs.org/pull-core/-/pull-core-1.1.0.tgz",
-              "integrity": "sha1-PYEn1trBR1cFyYAJYfWdZsgEbIo="
-            }
-          }
-        },
-        "stream-to-pull-stream": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/stream-to-pull-stream/-/stream-to-pull-stream-1.3.1.tgz",
-          "integrity": "sha1-9b6b4PHpS7PRrmaL/46SUbhabG4=",
-          "requires": {
-            "pull-core": "1.0.0"
-          }
-        }
-      }
-    },
-    "level-packager": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/level-packager/-/level-packager-1.2.1.tgz",
-      "integrity": "sha1-Bn/t/Qcrf+PGvsYIDAy9SmsuEfQ=",
-      "requires": {
-        "levelup": "1.3.9"
-      },
-      "dependencies": {
-        "abstract-leveldown": {
-          "version": "2.6.3",
-          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.6.3.tgz",
-          "integrity": "sha512-2++wDf/DYqkPR3o5tbfdhF96EfMApo1GpPfzOsR/ZYXdkSmELlvOOEAl9iKkRsktMPHdGjO4rtkBpf2I7TiTeA==",
-          "requires": {
-            "xtend": "4.0.1"
-          }
-        },
-        "deferred-leveldown": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-1.2.2.tgz",
-          "integrity": "sha512-uukrWD2bguRtXilKt6cAWKyoXrTSMo5m7crUdLfWQmu8kIm88w3QZoUL+6nhpfKVmhHANER6Re3sKoNoZ3IKMA==",
-          "requires": {
-            "abstract-leveldown": "2.6.3"
-          }
-        },
-        "level-codec": {
-          "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-7.0.1.tgz",
-          "integrity": "sha512-Ua/R9B9r3RasXdRmOtd+t9TCOEIIlts+TN/7XTT2unhDaL6sJn83S3rUyljbr6lVtw49N3/yA0HHjpV6Kzb2aQ=="
-        },
-        "levelup": {
-          "version": "1.3.9",
-          "resolved": "https://registry.npmjs.org/levelup/-/levelup-1.3.9.tgz",
-          "integrity": "sha512-VVGHfKIlmw8w1XqpGOAGwq6sZm2WwWLmlDcULkKWQXEA5EopA8OBNJ2Ck2v6bdk8HeEZSbCSEgzXadyQFm76sQ==",
-          "requires": {
-            "deferred-leveldown": "1.2.2",
-            "level-codec": "7.0.1",
-            "level-errors": "1.0.5",
-            "level-iterator-stream": "1.3.1",
-            "prr": "1.0.1",
-            "semver": "5.4.1",
-            "xtend": "4.0.1"
-          }
-        },
-        "prr": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
-          "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY="
-        },
-        "semver": {
-          "version": "5.4.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-          "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
-        }
-      }
-    },
-    "level-post": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/level-post/-/level-post-1.0.5.tgz",
-      "integrity": "sha1-KmY5BAm/ahYhpES6tvAWREzJgCw=",
-      "requires": {
-        "ltgt": "2.2.0"
-      }
-    },
-    "level-sublevel": {
-      "version": "6.6.1",
-      "resolved": "https://registry.npmjs.org/level-sublevel/-/level-sublevel-6.6.1.tgz",
-      "integrity": "sha1-+ad/dSGrcKj46S7VbyGjx4hqRIU=",
-      "requires": {
-        "bytewise": "1.1.0",
-        "levelup": "0.19.1",
-        "ltgt": "2.1.3",
-        "pull-level": "2.0.3",
-        "pull-stream": "3.6.1",
-        "typewiselite": "1.0.0",
-        "xtend": "4.0.1"
-      },
-      "dependencies": {
-        "ltgt": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.1.3.tgz",
-          "integrity": "sha1-EIUaBtmWS5cReEQcI8nlJpjuzjQ="
-        }
-      }
-    },
-    "leveldown": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/leveldown/-/leveldown-1.7.2.tgz",
-      "integrity": "sha1-XjRnuyfuJGpKe429j7KxYgam64s=",
-      "requires": {
-        "abstract-leveldown": "2.6.3",
-        "bindings": "1.2.1",
-        "fast-future": "1.0.2",
-        "nan": "2.6.2",
-        "prebuild-install": "2.5.0"
-      },
-      "dependencies": {
-        "abstract-leveldown": {
-          "version": "2.6.3",
-          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.6.3.tgz",
-          "integrity": "sha512-2++wDf/DYqkPR3o5tbfdhF96EfMApo1GpPfzOsR/ZYXdkSmELlvOOEAl9iKkRsktMPHdGjO4rtkBpf2I7TiTeA==",
-          "requires": {
-            "xtend": "4.0.1"
-          }
-        },
-        "nan": {
-          "version": "2.6.2",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.6.2.tgz",
-          "integrity": "sha1-5P805slf37WuzAjeZZb0NgWn20U="
-        }
-      }
-    },
-    "levelup": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/levelup/-/levelup-0.19.1.tgz",
-      "integrity": "sha1-86anIFJyxLXzXkEv8ASgOgrt9Qs=",
-      "requires": {
-        "bl": "0.8.2",
-        "deferred-leveldown": "0.2.0",
-        "errno": "0.1.6",
-        "prr": "0.0.0",
-        "readable-stream": "1.0.34",
-        "semver": "5.1.1",
-        "xtend": "3.0.0"
-      },
-      "dependencies": {
-        "xtend": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
-          "integrity": "sha1-XM50B7r2Qsunvs2laBEcST9ZZlo="
-        }
-      }
+      "integrity": "sha1-pLUkS7akwvcj1oodZOmAxTYn2dQ=",
+      "dev": true
     },
     "libsodium": {
-      "version": "0.2.12",
-      "resolved": "https://registry.npmjs.org/libsodium/-/libsodium-0.2.12.tgz",
-      "integrity": "sha1-gwg1ZNzwicuCpQNb6Sul0iSizN4="
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/libsodium/-/libsodium-0.7.4.tgz",
+      "integrity": "sha512-fTU3vUdrxQzhPAAjmTSqKk4LzYbR0OtcYjp1P92AlH50JIxXZFEIXWh1yryCmU6RLGfwS2IzBdZjbmpYf/TlyQ=="
     },
     "libsodium-wrappers": {
-      "version": "0.2.12",
-      "resolved": "https://registry.npmjs.org/libsodium-wrappers/-/libsodium-wrappers-0.2.12.tgz",
-      "integrity": "sha1-UftQd0uO3FF5J7MHuBKkbDpGfh4=",
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/libsodium-wrappers/-/libsodium-wrappers-0.7.4.tgz",
+      "integrity": "sha512-axKkW01L0q+urLeE7UMSZKWwk4LrRbi6s5pjKBAvbgDBYnsSaolK1oN/Syilm1dqJFkJQNi6qodwOp8dzSoc9Q==",
       "requires": {
-        "libsodium": "0.2.12"
-      }
-    },
-    "log-symbols": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
-      "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
-      "requires": {
-        "chalk": "1.1.3"
-      }
-    },
-    "log-update": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/log-update/-/log-update-1.0.2.tgz",
-      "integrity": "sha1-GZKfZMQJPS0ucHWh2tivWcKWuNE=",
-      "requires": {
-        "ansi-escapes": "1.4.0",
-        "cli-cursor": "1.0.2"
-      }
-    },
-    "longest-streak": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-1.0.0.tgz",
-      "integrity": "sha1-0GWXxNTDG1LMsfXY+P5xSOr9aWU="
-    },
-    "looper": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/looper/-/looper-4.0.0.tgz",
-      "integrity": "sha1-dwat7VmpntygbmtUu4bI7BnJUVU="
-    },
-    "lru-cache": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
-      "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
-      "requires": {
-        "pseudomap": "1.0.2",
-        "yallist": "2.1.2"
-      }
-    },
-    "ltgt": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.2.0.tgz",
-      "integrity": "sha1-tlul/LNJopkkyOMz98alVi8uSEI="
-    },
-    "map-filter-reduce": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/map-filter-reduce/-/map-filter-reduce-2.2.1.tgz",
-      "integrity": "sha1-YysSfDrl1q2eIc/dlpG2O4lE/NI=",
-      "requires": {
-        "binary-search": "1.3.2",
-        "pull-sink-through": "0.0.0",
-        "pull-stream": "3.6.1",
-        "typewiselite": "1.0.0"
-      }
-    },
-    "map-merge": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/map-merge/-/map-merge-1.1.0.tgz",
-      "integrity": "sha1-am/FjJXYqrRsK93kTVFbbuBvzjQ="
-    },
-    "markdown-table": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-0.4.0.tgz",
-      "integrity": "sha1-iQwsGzv+g/sA5BKbjkz+ZFJw+dE="
-    },
-    "mdmanifest": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/mdmanifest/-/mdmanifest-1.0.8.tgz",
-      "integrity": "sha1-wEiRiDwoyDYC4dBrBaEQN+NZtMg=",
-      "requires": {
-        "minimist": "1.2.0",
-        "remark": "3.2.3",
-        "remark-html": "2.0.2",
-        "word-wrap": "1.2.3"
-      }
-    },
-    "micromatch": {
-      "version": "2.3.11",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-      "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-      "requires": {
-        "arr-diff": "2.0.0",
-        "array-unique": "0.2.1",
-        "braces": "1.8.5",
-        "expand-brackets": "0.1.5",
-        "extglob": "0.3.2",
-        "filename-regex": "2.0.1",
-        "is-extglob": "1.0.0",
-        "is-glob": "2.0.1",
-        "kind-of": "3.2.2",
-        "normalize-path": "2.1.1",
-        "object.omit": "2.0.1",
-        "parse-glob": "3.0.4",
-        "regex-cache": "0.4.4"
+        "libsodium": "0.7.4"
       }
     },
     "minimatch": {
@@ -2430,13 +320,14 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "requires": {
-        "brace-expansion": "1.1.8"
+        "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+      "dev": true
     },
     "mkdirp": {
       "version": "0.5.1",
@@ -2453,396 +344,70 @@
         }
       }
     },
-    "monotonic-timestamp": {
-      "version": "0.0.9",
-      "resolved": "https://registry.npmjs.org/monotonic-timestamp/-/monotonic-timestamp-0.0.9.tgz",
-      "integrity": "sha1-W6Wtx6rIXh1853voRxYe0kazlgM="
+    "moo": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/moo/-/moo-0.4.3.tgz",
+      "integrity": "sha512-gFD2xGCl8YFgGHsqJ9NKRVdwlioeW3mI1iqfLNYQOv0+6JRwG58Zk9DIGQgyIaffSYaO1xsKnMaYzzNr1KyIAw==",
+      "dev": true
     },
-    "ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-    },
-    "multiblob": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/multiblob/-/multiblob-1.12.0.tgz",
-      "integrity": "sha1-WbTrvTvB+8CzpHPlhxwrSD1ON4A=",
+    "multiserver-address": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/multiserver-address/-/multiserver-address-1.0.1.tgz",
+      "integrity": "sha512-IfZMAGs9onCLkYNSnNBri3JxuvhQYllMyh3W9ry86iEDcfW9uPVsHTHDsjDxQtL+dPq3byshmA+Y4LN2wLHwNw==",
+      "dev": true,
       "requires": {
-        "blake2s": "1.0.1",
-        "cont": "1.0.3",
-        "explain-error": "1.0.4",
-        "mkdirp": "0.5.1",
-        "pull-cat": "1.1.11",
-        "pull-defer": "0.2.2",
-        "pull-file": "0.5.0",
-        "pull-glob": "1.0.6",
-        "pull-live": "1.0.1",
-        "pull-notify": "0.0.2",
-        "pull-paramap": "1.2.2",
-        "pull-stream": "3.6.1",
-        "pull-write-file": "0.2.4",
-        "rc": "0.5.5",
-        "rimraf": "2.2.8"
-      },
-      "dependencies": {
-        "deep-extend": {
-          "version": "0.2.11",
-          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.2.11.tgz",
-          "integrity": "sha1-eha6aXKRMjQFBhcElLyD9wdv4I8="
-        },
-        "minimist": {
-          "version": "0.0.10",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-          "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8="
-        },
-        "pull-file": {
-          "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/pull-file/-/pull-file-0.5.0.tgz",
-          "integrity": "sha1-s8pAUwbggvnUUoKIkzutsrZWNls=",
-          "requires": {
-            "pull-utf8-decoder": "1.0.2"
-          }
-        },
-        "pull-notify": {
-          "version": "0.0.2",
-          "resolved": "https://registry.npmjs.org/pull-notify/-/pull-notify-0.0.2.tgz",
-          "integrity": "sha1-KAu7oaV2g+IqOCBrKYlGXyQFGCE=",
-          "requires": {
-            "pull-pushable": "2.1.2"
-          }
-        },
-        "rc": {
-          "version": "0.5.5",
-          "resolved": "https://registry.npmjs.org/rc/-/rc-0.5.5.tgz",
-          "integrity": "sha1-VBzDMA9GS23+ZDLXVvDy3T6esZk=",
-          "requires": {
-            "deep-extend": "0.2.11",
-            "ini": "1.3.5",
-            "minimist": "0.0.10",
-            "strip-json-comments": "0.1.3"
-          }
-        },
-        "rimraf": {
-          "version": "2.2.8",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
-          "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI="
-        },
-        "strip-json-comments": {
-          "version": "0.1.3",
-          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-0.1.3.tgz",
-          "integrity": "sha1-Fkxk43Coo8wAyeAbU55WmCPw7lQ="
-        }
-      }
-    },
-    "multiblob-http": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/multiblob-http/-/multiblob-http-0.2.1.tgz",
-      "integrity": "sha1-N8C+qsxx0YNgEsBi282teX0CIps=",
-      "requires": {
-        "pull-stream": "3.6.1",
-        "stream-to-pull-stream": "1.7.2"
-      }
-    },
-    "multicb": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/multicb/-/multicb-1.2.2.tgz",
-      "integrity": "sha512-PZM4dhYFmCF6uZGWpEmoPMUqJBywS9IcAgybT2GmSpYI1BvGvoWSdbio+ik+q/YD2vodhvslESWIS3NnkKYdqQ=="
-    },
-    "multiserver": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/multiserver/-/multiserver-1.10.1.tgz",
-      "integrity": "sha1-WiP57wpI9ldDEOCT4qos+lrrka0=",
-      "requires": {
-        "pull-cat": "1.1.11",
-        "pull-stream": "3.6.1",
-        "pull-ws": "3.3.0",
-        "secret-handshake": "1.1.12",
-        "separator-escape": "0.0.0",
-        "socks": "1.1.9",
-        "stream-to-pull-stream": "1.7.2"
-      }
-    },
-    "muxrpc": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/muxrpc/-/muxrpc-6.4.0.tgz",
-      "integrity": "sha1-JPfaBpvUYpsHfpk7BXeUKyaI6ug=",
-      "requires": {
-        "explain-error": "1.0.4",
-        "packet-stream": "2.0.2",
-        "packet-stream-codec": "1.1.2",
-        "pull-goodbye": "0.0.2",
-        "pull-stream": "3.6.1"
-      }
-    },
-    "muxrpc-validation": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/muxrpc-validation/-/muxrpc-validation-2.0.1.tgz",
-      "integrity": "sha1-zWUNFyAl/p0GQjCqs4ymMo3Rby8=",
-      "requires": {
-        "pull-stream": "2.28.4",
-        "zerr": "1.0.4"
-      },
-      "dependencies": {
-        "pull-stream": {
-          "version": "2.28.4",
-          "resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-2.28.4.tgz",
-          "integrity": "sha1-fql0E8FhnCC8O9+eEOkTR7AyU+Q=",
-          "requires": {
-            "pull-core": "1.1.0"
-          }
-        }
-      }
-    },
-    "muxrpcli": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/muxrpcli/-/muxrpcli-1.1.0.tgz",
-      "integrity": "sha1-Sum6mGq4JcSlwS/LccbaqB6rUVg=",
-      "requires": {
-        "minimist": "1.2.0",
-        "pull-stream": "2.28.4",
-        "stream-to-pull-stream": "1.7.2",
-        "word-wrap": "1.2.3"
-      },
-      "dependencies": {
-        "pull-stream": {
-          "version": "2.28.4",
-          "resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-2.28.4.tgz",
-          "integrity": "sha1-fql0E8FhnCC8O9+eEOkTR7AyU+Q=",
-          "requires": {
-            "pull-core": "1.1.0"
-          }
-        }
-      }
-    },
-    "mv": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/mv/-/mv-2.1.1.tgz",
-      "integrity": "sha1-rmzg1vbV4KT32JN5jQPB6pVZtqI=",
-      "requires": {
-        "mkdirp": "0.5.1",
-        "ncp": "2.0.0",
-        "rimraf": "2.4.5"
-      },
-      "dependencies": {
-        "rimraf": {
-          "version": "2.4.5",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.5.tgz",
-          "integrity": "sha1-7nEM5dk6j9uFb7Xqj/Di11k0sto=",
-          "requires": {
-            "glob": "6.0.4"
-          }
-        }
+        "nearley": "^2.15.1"
       }
     },
     "nan": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.8.0.tgz",
-      "integrity": "sha1-7XFfP+neArV6XmJS2QqWZ14fCFo="
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
+      "optional": true
     },
-    "ncp": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
-      "integrity": "sha1-GVoh1sRuNh0vsSgbo4uR6d9727M="
-    },
-    "node-abi": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.2.0.tgz",
-      "integrity": "sha512-FqVC0WNNL8fQWQK3GYTESfwZXZKDbSIiEEIvufq7HV6Lj0IDDZRVa4CU/KTA0JVlqY9eTDSuPiC8FS9UfGVuzA==",
+    "nearley": {
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/nearley/-/nearley-2.16.0.tgz",
+      "integrity": "sha512-Tr9XD3Vt/EujXbZBv6UAHYoLUSMQAxSsTnm9K3koXzjzNWY195NqALeyrzLZBKzAkL3gl92BcSogqrHjD8QuUg==",
+      "dev": true,
       "requires": {
-        "semver": "5.5.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-          "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
-        }
+        "commander": "^2.19.0",
+        "moo": "^0.4.3",
+        "railroad-diagrams": "^1.0.0",
+        "randexp": "0.4.6",
+        "semver": "^5.4.1"
       }
     },
     "node-gyp-build": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-3.2.2.tgz",
-      "integrity": "sha512-t8W/0UqFGl1c+5ORA3NoT3npU+PxWBL9iPhY7ZySSTszodj3RWexmu8niayWBE0v+0DLARvOXsjaAvfmSEQOyQ=="
-    },
-    "non-private-ip": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/non-private-ip/-/non-private-ip-1.1.0.tgz",
-      "integrity": "sha1-RvRTUtUPaHNA5MAR9xY8ptGQdAM=",
-      "requires": {
-        "ip": "0.3.3"
-      }
-    },
-    "noop-logger": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/noop-logger/-/noop-logger-0.1.1.tgz",
-      "integrity": "sha1-lKKxYzxPExdVMAfYlm/Q6EG2pMI="
-    },
-    "normalize-path": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-      "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-      "requires": {
-        "remove-trailing-separator": "1.1.0"
-      }
-    },
-    "normalize-uri": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/normalize-uri/-/normalize-uri-1.1.0.tgz",
-      "integrity": "sha1-AftEDH/QWbnZvoZFqsFDQe/QWd0="
-    },
-    "npm-prefix": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/npm-prefix/-/npm-prefix-1.2.0.tgz",
-      "integrity": "sha1-5hlFX3B0ulTMZtbQ033Z8b5ry8A=",
-      "requires": {
-        "rc": "1.2.4",
-        "shellsubstitute": "1.2.0",
-        "untildify": "2.1.0"
-      }
-    },
-    "npmlog": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
-      "requires": {
-        "are-we-there-yet": "1.1.4",
-        "console-control-strings": "1.1.0",
-        "gauge": "2.7.4",
-        "set-blocking": "2.0.0"
-      }
-    },
-    "number-is-nan": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
-    },
-    "object-assign": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-3.9.0.tgz",
+      "integrity": "sha512-zLcTg6P4AbcHPq465ZMFNXx7XpKKJh+7kkN699NiQWisR2uWYOWNWqRHAmbnmKiL4e9aLSlmy5U7rEMUXV59+A==",
+      "optional": true
     },
     "object-inspect": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.3.0.tgz",
-      "integrity": "sha512-OHHnLgLNXpM++GnJRyyhbr2bwl3pPVm4YvaraHrRvDt/N3r+s/gDVHciA7EJBTkijKXj61ssgSAikq1fb0IBRg==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.6.0.tgz",
+      "integrity": "sha512-GJzfBZ6DgDAmnuaM3104jR4s1Myxr3Y3zfIyN4z3UdqN69oSRacNK8UhnobDdC+7J2AHCjGwxQubNJfE70SXXQ==",
       "dev": true
     },
     "object-keys": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
-      "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0=",
-      "dev": true
-    },
-    "object.omit": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
-      "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
-      "requires": {
-        "for-own": "0.1.5",
-        "is-extendable": "0.1.1"
-      }
-    },
-    "observ": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/observ/-/observ-0.2.0.tgz",
-      "integrity": "sha1-C8ObPin6pfnmyqWQbLg5LfQAqmg="
-    },
-    "observ-debounce": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/observ-debounce/-/observ-debounce-1.1.1.tgz",
-      "integrity": "sha1-ME6XyFrdpw7NfwjaRQZ475Dwtwc=",
-      "requires": {
-        "observ": "0.2.0"
-      }
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true
     },
     "obv": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/obv/-/obv-0.0.1.tgz",
-      "integrity": "sha1-yyNhBjQVNvDaxIFeBnCCIcrX+14="
-    },
-    "on-change-network": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/on-change-network/-/on-change-network-0.0.2.tgz",
-      "integrity": "sha1-2XcklHf5FyaUnYDoI0batu9FIWs="
-    },
-    "on-wakeup": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/on-wakeup/-/on-wakeup-1.0.1.tgz",
-      "integrity": "sha1-ANedmH3efIEXvudLtJA/b22vpSs="
+      "integrity": "sha1-yyNhBjQVNvDaxIFeBnCCIcrX+14=",
+      "dev": true
     },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
-        "wrappy": "1.0.2"
-      }
-    },
-    "onetime": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
-      "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k="
-    },
-    "options": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",
-      "integrity": "sha1-7CLTEoBrtT5zF3Pnza788cZDEo8="
-    },
-    "os-homedir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
-    },
-    "os-tmpdir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
-    },
-    "osenv": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
-      "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
-      "requires": {
-        "os-homedir": "1.0.2",
-        "os-tmpdir": "1.0.2"
-      }
-    },
-    "packet-stream": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/packet-stream/-/packet-stream-2.0.2.tgz",
-      "integrity": "sha1-uQt/m6tKliQiy8nLJHGcNT5JMmc="
-    },
-    "packet-stream-codec": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/packet-stream-codec/-/packet-stream-codec-1.1.2.tgz",
-      "integrity": "sha1-ebMC/BRM37tKtv66cEDmpdmcecc=",
-      "requires": {
-        "pull-reader": "1.2.9",
-        "pull-through": "1.0.18"
-      }
-    },
-    "parse-entities": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-1.1.1.tgz",
-      "integrity": "sha1-gRLYhHExnyerrk1klksSL+ThuJA=",
-      "requires": {
-        "character-entities": "1.2.1",
-        "character-entities-legacy": "1.1.1",
-        "character-reference-invalid": "1.1.1",
-        "is-alphanumerical": "1.0.1",
-        "is-decimal": "1.0.1",
-        "is-hexadecimal": "1.0.1"
-      }
-    },
-    "parse-glob": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
-      "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
-      "requires": {
-        "glob-base": "0.3.0",
-        "is-dotfile": "1.0.3",
-        "is-extglob": "1.0.0",
-        "is-glob": "2.0.1"
+        "wrappy": "1"
       }
     },
     "path-is-absolute": {
@@ -2851,607 +416,75 @@
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-parse": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
-      "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
       "dev": true
     },
-    "pify": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
-    },
-    "pinkie": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
-    },
-    "pinkie-promise": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-      "requires": {
-        "pinkie": "2.0.4"
-      }
-    },
-    "plur": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/plur/-/plur-2.1.2.tgz",
-      "integrity": "sha1-dIJFLBoPUI4+NE6uwxLJHCncZVo=",
-      "requires": {
-        "irregular-plurals": "1.4.0"
-      }
-    },
-    "prebuild-install": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-2.5.0.tgz",
-      "integrity": "sha512-3wlyZgmkeeyduOR8Ursu5gKr3yWAYObACa5aJOtt2farRRFV/+zXk/Y3wM6yQRMqmqHh+pHAwyKp5r82K699Rg==",
-      "requires": {
-        "detect-libc": "1.0.3",
-        "expand-template": "1.1.0",
-        "github-from-package": "0.0.0",
-        "minimist": "1.2.0",
-        "mkdirp": "0.5.1",
-        "node-abi": "2.2.0",
-        "noop-logger": "0.1.1",
-        "npmlog": "4.1.2",
-        "os-homedir": "1.0.2",
-        "pump": "1.0.3",
-        "rc": "1.2.4",
-        "simple-get": "1.4.3",
-        "tar-fs": "1.16.0",
-        "tunnel-agent": "0.6.0",
-        "xtend": "4.0.1"
-      }
-    },
-    "preserve": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
-      "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
-    },
     "private-box": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/private-box/-/private-box-0.2.1.tgz",
-      "integrity": "sha1-HfBhr8pbMDnH/qrdDa8PVvB+PsA=",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/private-box/-/private-box-0.3.0.tgz",
+      "integrity": "sha512-zsK6DDEC+cnNiunYamcVbx4ZCLbKnzTOZa09K4Pj3/tH3nQFPUO9K2QoYy4kfxLqmoyw6RPDtACN9OYviMQZ2Q==",
       "requires": {
-        "chloride": "2.2.8"
+        "chloride": "^2.2.9"
       }
     },
-    "process-nextick-args": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
-    },
-    "prr": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz",
-      "integrity": "sha1-GoS4WQgyVQFBGFPQCB7j+obikmo="
-    },
-    "pseudomap": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
-    },
-    "pull-abortable": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/pull-abortable/-/pull-abortable-4.1.1.tgz",
-      "integrity": "sha1-s61a77QRayWRbSbbiTk6yY0NzqE="
-    },
-    "pull-box-stream": {
-      "version": "1.0.13",
-      "resolved": "https://registry.npmjs.org/pull-box-stream/-/pull-box-stream-1.0.13.tgz",
-      "integrity": "sha1-w+JAOY6rP1lRsu0QeMWYi/egork=",
-      "requires": {
-        "chloride": "2.2.8",
-        "increment-buffer": "1.0.1",
-        "pull-reader": "1.2.9",
-        "pull-stream": "3.6.1",
-        "pull-through": "1.0.18",
-        "split-buffer": "1.0.0"
-      }
-    },
-    "pull-cat": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/pull-cat/-/pull-cat-1.1.11.tgz",
-      "integrity": "sha1-tkLdElXaN2pwa220+pYvX9t0wxs="
-    },
-    "pull-cont": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/pull-cont/-/pull-cont-0.0.0.tgz",
-      "integrity": "sha1-P6xIuBrJe3W6ATMgiLDOevjBvg4="
-    },
-    "pull-core": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/pull-core/-/pull-core-1.1.0.tgz",
-      "integrity": "sha1-PYEn1trBR1cFyYAJYfWdZsgEbIo="
-    },
-    "pull-cursor": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/pull-cursor/-/pull-cursor-2.1.3.tgz",
-      "integrity": "sha1-Ah6X19I9eK9mrda4wcF/1v2xK2w=",
-      "requires": {
-        "looper": "4.0.0",
-        "ltgt": "2.2.0",
-        "pull-stream": "3.6.1"
-      }
+    "promisize": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/promisize/-/promisize-1.1.2.tgz",
+      "integrity": "sha1-m0fiyyrkl+seutwsQZHWTRXJSdE=",
+      "dev": true
     },
     "pull-defer": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/pull-defer/-/pull-defer-0.2.2.tgz",
-      "integrity": "sha1-CIew/7MK8ypW2+z6csFnInHwexM="
-    },
-    "pull-file": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/pull-file/-/pull-file-1.1.0.tgz",
-      "integrity": "sha1-HdmHYF1jV6DSPB5Lgm95FaIVEpw=",
-      "requires": {
-        "pull-utf8-decoder": "1.0.2"
-      }
-    },
-    "pull-flatmap": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/pull-flatmap/-/pull-flatmap-0.0.1.tgz",
-      "integrity": "sha1-E9SURT6PbUeOe7+t5vj+AZf6a7c="
-    },
-    "pull-fs": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/pull-fs/-/pull-fs-1.1.6.tgz",
-      "integrity": "sha1-8YT2p3KLtNlWQTdr6tafb2bfR80=",
-      "requires": {
-        "pull-file": "0.5.0",
-        "pull-stream": "3.6.1",
-        "pull-traverse": "1.0.3",
-        "pull-write-file": "0.2.4"
-      },
-      "dependencies": {
-        "pull-file": {
-          "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/pull-file/-/pull-file-0.5.0.tgz",
-          "integrity": "sha1-s8pAUwbggvnUUoKIkzutsrZWNls=",
-          "requires": {
-            "pull-utf8-decoder": "1.0.2"
-          }
-        }
-      }
-    },
-    "pull-glob": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/pull-glob/-/pull-glob-1.0.6.tgz",
-      "integrity": "sha1-3qWsWUjuFZeNqyTXdyApJ/aK6KY=",
-      "requires": {
-        "pull-fs": "1.1.6",
-        "pull-stream": "3.6.1"
-      }
-    },
-    "pull-goodbye": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/pull-goodbye/-/pull-goodbye-0.0.2.tgz",
-      "integrity": "sha1-jYNX21XiKnEN//DxaoyQtF7+QXE=",
-      "requires": {
-        "pull-stream": "3.5.0"
-      },
-      "dependencies": {
-        "pull-stream": {
-          "version": "3.5.0",
-          "resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-3.5.0.tgz",
-          "integrity": "sha1-HuW292/Ts6SaWvtt7VwDIKyzz8c="
-        }
-      }
-    },
-    "pull-handshake": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/pull-handshake/-/pull-handshake-1.1.4.tgz",
-      "integrity": "sha1-YACg/QGIhM39c3JU+Mxgqypjd5E=",
-      "requires": {
-        "pull-cat": "1.1.11",
-        "pull-pair": "1.1.0",
-        "pull-pushable": "2.1.2",
-        "pull-reader": "1.2.9"
-      }
-    },
-    "pull-hash": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/pull-hash/-/pull-hash-1.0.0.tgz",
-      "integrity": "sha1-/K1NJQe/LCsyMfZT3Jv7LbTw2Iw="
-    },
-    "pull-inactivity": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/pull-inactivity/-/pull-inactivity-2.1.2.tgz",
-      "integrity": "sha1-N6PW67+sKSzUNfXkgeUHTIwfrXU=",
-      "requires": {
-        "pull-abortable": "4.0.0",
-        "pull-stream": "3.6.1"
-      },
-      "dependencies": {
-        "pull-abortable": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/pull-abortable/-/pull-abortable-4.0.0.tgz",
-          "integrity": "sha1-cBephMO4NN53usOMELd28i38GEM="
-        }
-      }
-    },
-    "pull-level": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/pull-level/-/pull-level-2.0.3.tgz",
-      "integrity": "sha1-lQBjXiV5Rdb+7eGF9deiR3NFWxc=",
-      "requires": {
-        "level-post": "1.0.5",
-        "pull-cat": "1.1.11",
-        "pull-live": "1.0.1",
-        "pull-pushable": "2.1.2",
-        "pull-stream": "3.6.1",
-        "pull-window": "2.1.4",
-        "stream-to-pull-stream": "1.7.2"
-      }
-    },
-    "pull-live": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/pull-live/-/pull-live-1.0.1.tgz",
-      "integrity": "sha1-pOzuAeMwFV6RJLu89HYfIbOPUfU=",
-      "requires": {
-        "pull-cat": "1.1.11",
-        "pull-stream": "3.6.1"
-      }
-    },
-    "pull-looper": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/pull-looper/-/pull-looper-1.0.0.tgz",
-      "integrity": "sha512-djlD60A6NGe5goLdP5pgbqzMEiWmk1bInuAzBp0QOH4vDrVwh05YDz6UP8+pOXveKEk8wHVP+rB2jBrK31QMPA==",
-      "requires": {
-        "looper": "4.0.0"
-      }
-    },
-    "pull-many": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/pull-many/-/pull-many-1.0.8.tgz",
-      "integrity": "sha1-Pa3ZttFWxUVyG9qNAAPdjqoGKT4=",
-      "requires": {
-        "pull-stream": "3.6.1"
-      }
-    },
-    "pull-next": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/pull-next/-/pull-next-1.0.1.tgz",
-      "integrity": "sha1-A/TX0Zhy/BEUFh6I227PTGXmHlY="
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/pull-defer/-/pull-defer-0.2.3.tgz",
+      "integrity": "sha512-/An3KE7mVjZCqNhZsr22k1Tx8MACnUnHZZNPSJ0S62td8JtYr/AiRG42Vz7Syu31SoTLUzVIe61jtT/pNdjVYA==",
+      "dev": true
     },
     "pull-notify": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/pull-notify/-/pull-notify-0.1.1.tgz",
       "integrity": "sha1-b4b/ldJwuJw+vyVbYDG3Ay3JnMo=",
+      "dev": true,
       "requires": {
-        "pull-pushable": "2.1.2"
-      }
-    },
-    "pull-pair": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/pull-pair/-/pull-pair-1.1.0.tgz",
-      "integrity": "sha1-fuQnJj/fTaglOXrAoF4atLdL120="
-    },
-    "pull-paramap": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/pull-paramap/-/pull-paramap-1.2.2.tgz",
-      "integrity": "sha1-UaQZPOnI1yFdla2tReK824STsjo=",
-      "requires": {
-        "looper": "4.0.0"
-      }
-    },
-    "pull-ping": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/pull-ping/-/pull-ping-2.0.2.tgz",
-      "integrity": "sha1-e8SjQBZ9rYj2gqGWxjSFc1x6CJQ=",
-      "requires": {
-        "pull-pushable": "2.1.2",
-        "pull-stream": "3.6.1",
-        "statistics": "3.3.0"
+        "pull-pushable": "^2.0.0"
       }
     },
     "pull-pushable": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/pull-pushable/-/pull-pushable-2.1.2.tgz",
-      "integrity": "sha1-P+Fbj37sifOXLSOLwEiQyUBabbs="
-    },
-    "pull-rate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/pull-rate/-/pull-rate-1.0.2.tgz",
-      "integrity": "sha1-F7IxrV81n2dYJmcBcrDlkMiWTo0=",
-      "requires": {
-        "pull-stream": "3.6.1"
-      }
-    },
-    "pull-reader": {
-      "version": "1.2.9",
-      "resolved": "https://registry.npmjs.org/pull-reader/-/pull-reader-1.2.9.tgz",
-      "integrity": "sha1-0umtALz7VOYqpm1Cwtu8tetoQ7A="
-    },
-    "pull-sink-through": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/pull-sink-through/-/pull-sink-through-0.0.0.tgz",
-      "integrity": "sha1-08BJLzqAtO0gSvZ8S0+TVoD8Wx8="
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pull-pushable/-/pull-pushable-2.2.0.tgz",
+      "integrity": "sha1-Xy867UethpGfAbEqLpnW8b13ZYE=",
+      "dev": true
     },
     "pull-stream": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-3.6.1.tgz",
-      "integrity": "sha1-xcKuSlEkbv7rzGXAQSo9clqSzgA="
+      "version": "3.6.13",
+      "resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-3.6.13.tgz",
+      "integrity": "sha512-enbnbnO+czsPuCq9s9HTTzDzzVQD5TSe60aO3nBioeJ9mevh8RzE4Hxbujo9TReg1fJlmNEL8uyQTUgn8+rSHg==",
+      "dev": true
     },
-    "pull-stream-to-stream": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/pull-stream-to-stream/-/pull-stream-to-stream-1.3.4.tgz",
-      "integrity": "sha1-P4HYIWvRjSv9GhmBkEcRgOJzg5k="
+    "railroad-diagrams": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
+      "integrity": "sha1-635iZ1SN3t+4mcG5Dlc3RVnN234=",
+      "dev": true
     },
-    "pull-stringify": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/pull-stringify/-/pull-stringify-1.2.2.tgz",
-      "integrity": "sha1-Whw04Adfry8vbUYATjbczTO9fHw="
-    },
-    "pull-through": {
-      "version": "1.0.18",
-      "resolved": "https://registry.npmjs.org/pull-through/-/pull-through-1.0.18.tgz",
-      "integrity": "sha1-jdYjFCY+Wc9Qlur7sSeitu8xBzU=",
-      "requires": {
-        "looper": "3.0.0"
-      },
-      "dependencies": {
-        "looper": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/looper/-/looper-3.0.0.tgz",
-          "integrity": "sha1-LvpUw7HLq6m5Su4uWRSwvlf7t0k="
-        }
-      }
-    },
-    "pull-traverse": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/pull-traverse/-/pull-traverse-1.0.3.tgz",
-      "integrity": "sha1-dPtde+f6a9enjpeTPhmbeUWGaTg="
-    },
-    "pull-utf8-decoder": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/pull-utf8-decoder/-/pull-utf8-decoder-1.0.2.tgz",
-      "integrity": "sha1-p6+iOE0eZBWl1gIFQSbMjeO8vOc="
-    },
-    "pull-window": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/pull-window/-/pull-window-2.1.4.tgz",
-      "integrity": "sha1-/DuG/uvRkgx64pdpHiP3BfiFUvA=",
-      "requires": {
-        "looper": "2.0.0"
-      },
-      "dependencies": {
-        "looper": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/looper/-/looper-2.0.0.tgz",
-          "integrity": "sha1-Zs0Md0rz1P7axTeU90LbVtqPCew="
-        }
-      }
-    },
-    "pull-write": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/pull-write/-/pull-write-1.1.4.tgz",
-      "integrity": "sha1-3d6jFJO0j2douEooHQHrO1Mf4Lg=",
-      "requires": {
-        "looper": "4.0.0",
-        "pull-cat": "1.1.11",
-        "pull-stream": "3.6.1"
-      }
-    },
-    "pull-write-file": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/pull-write-file/-/pull-write-file-0.2.4.tgz",
-      "integrity": "sha1-Q3NErrIYn2XmeO0a838PdgpUU+8="
-    },
-    "pull-ws": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/pull-ws/-/pull-ws-3.3.0.tgz",
-      "integrity": "sha1-4cQ+9AMyFn3YEg71nt9+iSvqSq4=",
-      "requires": {
-        "relative-url": "1.0.2",
-        "safe-buffer": "5.1.1",
-        "ws": "1.1.5"
-      }
-    },
-    "pump": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz",
-      "integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
-      "requires": {
-        "end-of-stream": "1.4.1",
-        "once": "1.4.0"
-      }
-    },
-    "randomatic": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
-      "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
-      "requires": {
-        "is-number": "3.0.0",
-        "kind-of": "4.0.0"
-      },
-      "dependencies": {
-        "is-number": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-          "requires": {
-            "kind-of": "3.2.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "requires": {
-                "is-buffer": "1.1.6"
-              }
-            }
-          }
-        },
-        "kind-of": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
-          "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
-          "requires": {
-            "is-buffer": "1.1.6"
-          }
-        }
-      }
-    },
-    "rc": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.4.tgz",
-      "integrity": "sha1-oPYGyq4qO4YrvQ74VILAElsxX6M=",
-      "requires": {
-        "deep-extend": "0.4.2",
-        "ini": "1.3.5",
-        "minimist": "1.2.0",
-        "strip-json-comments": "2.0.1"
-      }
-    },
-    "readable-stream": {
-      "version": "1.0.34",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-      "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-      "requires": {
-        "core-util-is": "1.0.2",
-        "inherits": "2.0.3",
-        "isarray": "0.0.1",
-        "string_decoder": "0.10.31"
-      }
-    },
-    "readdirp": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
-      "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
-      "requires": {
-        "graceful-fs": "4.1.11",
-        "minimatch": "3.0.4",
-        "readable-stream": "2.3.3",
-        "set-immediate-shim": "1.0.1"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-        },
-        "readable-stream": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
-          }
-        },
-        "string_decoder": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
-        }
-      }
-    },
-    "regex-cache": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
-      "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
-      "requires": {
-        "is-equal-shallow": "0.1.3"
-      }
-    },
-    "relative-url": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/relative-url/-/relative-url-1.0.2.tgz",
-      "integrity": "sha1-0hxSpy1gYQGLzun5yfwQa/fWUoc="
-    },
-    "remark": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/remark/-/remark-3.2.3.tgz",
-      "integrity": "sha1-gCo4w6qYyeHj6gFe66IR0ny2Xh8=",
-      "requires": {
-        "camelcase": "2.1.1",
-        "ccount": "1.0.2",
-        "chalk": "1.1.3",
-        "chokidar": "1.7.0",
-        "collapse-white-space": "1.0.3",
-        "commander": "2.13.0",
-        "concat-stream": "1.6.0",
-        "debug": "2.6.9",
-        "elegant-spinner": "1.0.1",
-        "extend.js": "0.0.2",
-        "glob": "6.0.4",
-        "globby": "4.1.0",
-        "he": "0.5.0",
-        "log-update": "1.0.2",
-        "longest-streak": "1.0.0",
-        "markdown-table": "0.4.0",
-        "minimatch": "3.0.4",
-        "npm-prefix": "1.2.0",
-        "parse-entities": "1.1.1",
-        "repeat-string": "1.6.1",
-        "stringify-entities": "1.3.1",
-        "to-vfile": "1.0.0",
-        "trim": "0.0.1",
-        "trim-trailing-lines": "1.1.0",
-        "unified": "2.1.4",
-        "user-home": "2.0.0",
-        "vfile": "1.4.0",
-        "vfile-find-down": "1.0.0",
-        "vfile-find-up": "1.0.0",
-        "vfile-reporter": "1.5.0",
-        "ware": "1.3.0"
-      }
-    },
-    "remark-html": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/remark-html/-/remark-html-2.0.2.tgz",
-      "integrity": "sha1-WSo0e909WIH08IDJi1sVL7FAepI=",
-      "requires": {
-        "collapse-white-space": "1.0.3",
-        "detab": "1.0.2",
-        "normalize-uri": "1.1.0",
-        "object-assign": "4.1.1",
-        "trim": "0.0.1",
-        "trim-lines": "1.1.0",
-        "unist-util-visit": "1.3.0"
-      }
-    },
-    "remove-trailing-separator": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
-      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
-    },
-    "repeat-element": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
-      "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo="
-    },
-    "repeat-string": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
-    },
-    "resolve": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.4.0.tgz",
-      "integrity": "sha512-aW7sVKPufyHqOmyyLzg/J+8606v5nevBgaliIlV7nUpVMsDnoBGV/cbSLNjZAg9q0Cfd/+easKVKQ8vOu8fn1Q==",
+    "randexp": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.6.tgz",
+      "integrity": "sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==",
       "dev": true,
       "requires": {
-        "path-parse": "1.0.5"
+        "discontinuous-range": "1.0.0",
+        "ret": "~0.1.10"
       }
     },
-    "restore-cursor": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
-      "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+    "resolve": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.1.tgz",
+      "integrity": "sha512-vIpgF6wfuJOZI7KKKSP+HmiKggadPQAdsp5HiC1mvqnfp0gF1vdwgBWZIdrVft9pgqoMFQN+R7BSWZiBxx+BBw==",
+      "dev": true,
       "requires": {
-        "exit-hook": "1.1.1",
-        "onetime": "1.1.0"
+        "path-parse": "^1.0.6"
       }
     },
     "resumer": {
@@ -3460,556 +493,6978 @@
       "integrity": "sha1-8ej0YeQGS6Oegq883CqMiT0HZ1k=",
       "dev": true,
       "requires": {
-        "through": "2.3.8"
+        "through": "~2.3.4"
       }
     },
+    "ret": {
+      "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+      "dev": true
+    },
     "rimraf": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
       "requires": {
-        "glob": "7.1.2"
-      },
-      "dependencies": {
-        "glob": {
-          "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-          "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          }
-        }
+        "glob": "^7.1.3"
       }
     },
     "safe-buffer": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
-    },
-    "scuttlebot": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/scuttlebot/-/scuttlebot-10.5.0.tgz",
-      "integrity": "sha1-nHJwHHjfr8/XAQCUnQAbZHUyzNI=",
-      "requires": {
-        "atomic-file": "0.0.1",
-        "bash-color": "0.0.4",
-        "broadcast-stream": "0.2.2",
-        "cont": "1.0.3",
-        "cross-spawn": "5.1.0",
-        "deep-equal": "1.0.1",
-        "explain-error": "1.0.4",
-        "flumedb": "0.4.6",
-        "flumelog-offset": "3.2.6",
-        "flumeview-reduce": "1.3.12",
-        "graphreduce": "3.0.4",
-        "has-network": "0.0.1",
-        "ip": "0.3.3",
-        "level-memview": "0.0.0",
-        "mdmanifest": "1.0.8",
-        "minimist": "1.2.0",
-        "mkdirp": "0.5.1",
-        "multiblob": "1.12.0",
-        "multicb": "1.2.2",
-        "muxrpc": "6.4.0",
-        "muxrpc-validation": "2.0.1",
-        "muxrpcli": "1.1.0",
-        "mv": "2.1.1",
-        "non-private-ip": "1.1.0",
-        "observ-debounce": "1.1.1",
-        "obv": "0.0.1",
-        "on-change-network": "0.0.2",
-        "on-wakeup": "1.0.1",
-        "osenv": "0.1.4",
-        "pull-abortable": "4.1.1",
-        "pull-cat": "1.1.11",
-        "pull-file": "1.1.0",
-        "pull-flatmap": "0.0.1",
-        "pull-inactivity": "2.1.2",
-        "pull-level": "2.0.3",
-        "pull-many": "1.0.8",
-        "pull-next": "1.0.1",
-        "pull-notify": "0.1.1",
-        "pull-paramap": "1.2.2",
-        "pull-ping": "2.0.2",
-        "pull-pushable": "2.1.2",
-        "pull-stream": "3.6.1",
-        "pull-stream-to-stream": "1.3.4",
-        "pull-stringify": "1.2.2",
-        "rimraf": "2.6.2",
-        "secret-stack": "4.0.1",
-        "secure-scuttlebutt": "17.1.1",
-        "sodium-native": "2.1.4",
-        "ssb-blobs": "1.1.4",
-        "ssb-client": "4.5.2",
-        "ssb-config": "2.2.0",
-        "ssb-friends": "2.4.0",
-        "ssb-keys": "7.0.13",
-        "ssb-links": "3.0.1",
-        "ssb-msgs": "5.2.0",
-        "ssb-query": "1.0.2",
-        "ssb-ref": "2.9.1",
-        "ssb-ws": "1.0.3",
-        "statistics": "3.3.0",
-        "stream-to-pull-stream": "1.7.2",
-        "zerr": "1.0.4"
-      }
-    },
-    "secret-handshake": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/secret-handshake/-/secret-handshake-1.1.12.tgz",
-      "integrity": "sha512-5K2rx7QLBOz/JFAWGevU0JsoeC/0PZufSFJPqxQefZSdhMmB2aO16CJ9rwfnAzwMZMGrM+F2/ljXTP9wHp4GlA==",
-      "requires": {
-        "chloride": "2.2.8",
-        "deep-equal": "1.0.1",
-        "pull-box-stream": "1.0.13",
-        "pull-handshake": "1.1.4",
-        "pull-stream": "3.6.1"
-      }
-    },
-    "secret-stack": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/secret-stack/-/secret-stack-4.0.1.tgz",
-      "integrity": "sha1-kvucB+zI+FHH9/5nybhDASZtzXk=",
-      "requires": {
-        "hoox": "0.0.1",
-        "ip": "1.1.5",
-        "map-merge": "1.1.0",
-        "multiserver": "1.10.1",
-        "muxrpc": "6.4.0",
-        "non-private-ip": "1.4.2",
-        "pull-inactivity": "2.1.2",
-        "pull-rate": "1.0.2",
-        "pull-stream": "3.6.1",
-        "stream-to-pull-stream": "1.7.2"
-      },
-      "dependencies": {
-        "ip": {
-          "version": "1.1.5",
-          "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
-          "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
-        },
-        "non-private-ip": {
-          "version": "1.4.2",
-          "resolved": "https://registry.npmjs.org/non-private-ip/-/non-private-ip-1.4.2.tgz",
-          "integrity": "sha1-7VH6e/fpGpxjI5TxBUe2o5Xovq0=",
-          "requires": {
-            "ip": "0.3.3"
-          },
-          "dependencies": {
-            "ip": {
-              "version": "0.3.3",
-              "resolved": "https://registry.npmjs.org/ip/-/ip-0.3.3.tgz",
-              "integrity": "sha1-jugwnpLwsEDSh/cu+soaIXAtP7Q="
-            }
-          }
-        }
-      }
-    },
-    "secure-scuttlebutt": {
-      "version": "17.1.1",
-      "resolved": "https://registry.npmjs.org/secure-scuttlebutt/-/secure-scuttlebutt-17.1.1.tgz",
-      "integrity": "sha1-3jcVeDxA3zTfaj25mt6GN7oPHLI=",
-      "requires": {
-        "async-write": "2.1.0",
-        "cont": "1.0.3",
-        "deep-equal": "0.2.2",
-        "explain-error": "1.0.4",
-        "flumecodec": "0.0.1",
-        "flumedb": "0.4.6",
-        "flumelog-offset": "3.2.6",
-        "flumeview-hashtable": "1.0.3",
-        "flumeview-level": "2.1.1",
-        "flumeview-reduce": "1.3.12",
-        "level": "1.7.0",
-        "level-sublevel": "6.6.1",
-        "ltgt": "2.2.0",
-        "monotonic-timestamp": "0.0.9",
-        "obv": "0.0.1",
-        "pull-cont": "0.0.0",
-        "pull-level": "2.0.3",
-        "pull-live": "1.0.1",
-        "pull-notify": "0.1.1",
-        "pull-paramap": "1.2.2",
-        "pull-stream": "3.6.1",
-        "ssb-keys": "7.0.13",
-        "ssb-msgs": "5.2.0",
-        "ssb-ref": "2.9.1",
-        "ssb-validate": "3.0.0",
-        "typewiselite": "1.0.0"
-      },
-      "dependencies": {
-        "deep-equal": {
-          "version": "0.2.2",
-          "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.2.2.tgz",
-          "integrity": "sha1-hLdFiW80xoTpjyzg5Cq69Du6AX0="
-        },
-        "flumecodec": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/flumecodec/-/flumecodec-0.0.1.tgz",
-          "integrity": "sha1-rgSacUOGu4PjQmV6gpJLcDZKkNY=",
-          "requires": {
-            "level-codec": "6.2.0"
-          }
-        }
-      }
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
+      "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
     },
     "semver": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.1.tgz",
-      "integrity": "sha1-oykqNz5vPgeY2gsgZBuanFvEfhk="
-    },
-    "separator-escape": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/separator-escape/-/separator-escape-0.0.0.tgz",
-      "integrity": "sha1-5DNnaTICBFTjwUhwxRfqHeVsL6Q="
-    },
-    "set-blocking": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
-    },
-    "set-immediate-shim": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
-      "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E="
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+      "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+      "dev": true
     },
     "sha.js": {
       "version": "2.4.5",
       "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.5.tgz",
       "integrity": "sha1-J9Fx78yCoRi5ljn/WBZgJCtQbnw=",
       "requires": {
-        "inherits": "2.0.3"
-      }
-    },
-    "shebang-command": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
-      "requires": {
-        "shebang-regex": "1.0.0"
-      }
-    },
-    "shebang-regex": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
-    },
-    "shellsubstitute": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/shellsubstitute/-/shellsubstitute-1.2.0.tgz",
-      "integrity": "sha1-5PcCpQxRiw9v6YRRiQ1wWvKba3A="
-    },
-    "signal-exit": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
-    },
-    "simple-get": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-1.4.3.tgz",
-      "integrity": "sha1-6XVe2kB+ltpAxeUVjJ6jezO+y+s=",
-      "requires": {
-        "once": "1.4.0",
-        "unzip-response": "1.0.2",
-        "xtend": "4.0.1"
-      }
-    },
-    "smart-buffer": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-1.1.15.tgz",
-      "integrity": "sha1-fxFLW2X6s+KjWqd1uxLw0cZJvxY="
-    },
-    "socks": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-1.1.9.tgz",
-      "integrity": "sha1-Yo1+TQSRJDVEWsC25Fk3bLPm1pE=",
-      "requires": {
-        "ip": "1.1.5",
-        "smart-buffer": "1.1.15"
-      },
-      "dependencies": {
-        "ip": {
-          "version": "1.1.5",
-          "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
-          "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
-        }
+        "inherits": "^2.0.1"
       }
     },
     "sodium-browserify": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/sodium-browserify/-/sodium-browserify-1.2.1.tgz",
-      "integrity": "sha1-sLVZyjaYFnkIUhSFXiZkXfZ6rxw=",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/sodium-browserify/-/sodium-browserify-1.2.7.tgz",
+      "integrity": "sha512-PGhNO8KravjroRDYvurMPRYi4xMM7zjTW10R77Nq9sjkU314YA2sPeXS6UA5k/rLHaXLaZ6YfLLVz+DdCU5w0g==",
       "requires": {
-        "libsodium-wrappers": "0.2.12",
+        "libsodium-wrappers": "^0.7.4",
         "sha.js": "2.4.5",
-        "tweetnacl": "0.14.5"
+        "sodium-browserify-tweetnacl": "^0.2.5",
+        "tweetnacl": "^0.14.1"
       }
     },
     "sodium-browserify-tweetnacl": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/sodium-browserify-tweetnacl/-/sodium-browserify-tweetnacl-0.2.3.tgz",
-      "integrity": "sha1-tVN//LufdOvEQ7i2ohGykej8vI4=",
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/sodium-browserify-tweetnacl/-/sodium-browserify-tweetnacl-0.2.6.tgz",
+      "integrity": "sha512-ZnEI26hdluilpYY28Xc4rc1ALfmEp2TWihkJX6Mdtw0z9RfHfpZJU7P8DoKbN1HcBdU9aJmguFZs7igE8nLJPg==",
       "requires": {
-        "chloride-test": "1.2.2",
-        "ed2curve": "0.1.4",
-        "sha.js": "2.4.10",
-        "tweetnacl": "0.14.5",
-        "tweetnacl-auth": "0.3.1"
+        "chloride-test": "^1.1.0",
+        "ed2curve": "^0.1.4",
+        "sha.js": "^2.4.8",
+        "tweetnacl": "^1.0.1",
+        "tweetnacl-auth": "^0.3.0"
       },
       "dependencies": {
         "sha.js": {
-          "version": "2.4.10",
-          "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.10.tgz",
-          "integrity": "sha512-vnwmrFDlOExK4Nm16J2KMWHLrp14lBrjxMxBJpu++EnsuBmpiYaM/MEs46Vxxm/4FvdP5yTwuCTO9it5FSjrqA==",
+          "version": "2.4.11",
+          "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+          "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
           "requires": {
-            "inherits": "2.0.3",
-            "safe-buffer": "5.1.1"
+            "inherits": "^2.0.1",
+            "safe-buffer": "^5.0.1"
           }
+        },
+        "tweetnacl": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.1.tgz",
+          "integrity": "sha512-kcoMoKTPYnoeS50tzoqjPY3Uv9axeuuFAZY9M/9zFnhoVvRfxz9K29IMPD7jGmt2c8SW7i3gT9WqDl2+nV7p4A=="
         }
       }
     },
     "sodium-chloride": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/sodium-chloride/-/sodium-chloride-1.1.0.tgz",
-      "integrity": "sha1-JHojS4iGf23/UTMrYF8ZOmW/aDk="
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/sodium-chloride/-/sodium-chloride-1.1.2.tgz",
+      "integrity": "sha512-8AVzr9VHueXqfzfkzUA0aXe/Q4XG3UTmhlP6Pt+HQc5bbAPIJFo7ZIMh9tvn+99QuiMcyDJdYumegGAczl0N+g=="
     },
     "sodium-native": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-2.1.4.tgz",
-      "integrity": "sha512-EiCWFVWp1useIOg+S4YZOsNv16dN+2J6RI2PKDiubhyrcP/YjK5O9XswkuEZUpgL0UMZb3S+u/J1eu9iXq412g==",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-2.4.2.tgz",
+      "integrity": "sha512-qwHcUnzFpRSGSm6F49j/h5SnxPFBgSNdDwZkAqjvuAoHQIVBFOXYb+oCUTJV80K5hRqSYCihpbX06vbrtPbilg==",
+      "optional": true,
       "requires": {
-        "ini": "1.3.5",
-        "nan": "2.8.0",
-        "node-gyp-build": "3.2.2"
+        "ini": "^1.3.5",
+        "nan": "^2.4.0",
+        "node-gyp-build": "^3.0.0"
       }
-    },
-    "split-buffer": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/split-buffer/-/split-buffer-1.0.0.tgz",
-      "integrity": "sha1-t+jgq1E0UVi3LB9tvvJAbVHx0Cc="
     },
     "ssb-about": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/ssb-about/-/ssb-about-0.1.2.tgz",
-      "integrity": "sha512-/dvDJZdvukOHTjWDAUDdi5euG3fHIgW0z8xIWI+n+C3ugDCPad24josbRBMtgJ6e5piKOzstTlumIqfekvv8YQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ssb-about/-/ssb-about-2.0.1.tgz",
+      "integrity": "sha512-j0inbLwsyQctspyW51eH7h+9rpLN7Mf8A2nNX4WIWWh3tjaqS7ZNec4W/Q/6bBaoJkgtMPKLNWvrPMQwYYT15g==",
       "dev": true,
       "requires": {
-        "flumeview-reduce": "1.3.12",
-        "ssb-ref": "2.9.1"
-      }
-    },
-    "ssb-blobs": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/ssb-blobs/-/ssb-blobs-1.1.4.tgz",
-      "integrity": "sha1-2T8pYLSU4QZXhp/zu59y32lxXck=",
-      "requires": {
-        "cont": "1.0.3",
-        "level": "1.7.0",
-        "multiblob": "1.12.0",
-        "pull-level": "1.5.2",
-        "pull-notify": "0.1.1",
-        "pull-stream": "3.6.1",
-        "ssb-ref": "2.9.1"
-      },
-      "dependencies": {
-        "pull-level": {
-          "version": "1.5.2",
-          "resolved": "https://registry.npmjs.org/pull-level/-/pull-level-1.5.2.tgz",
-          "integrity": "sha1-K0vcjquNTy43CLSVEjULFLsDW1Y=",
-          "requires": {
-            "level-post": "1.0.5",
-            "pull-cat": "1.1.11",
-            "pull-pushable": "2.1.2",
-            "pull-stream": "3.6.1",
-            "pull-window": "2.1.4",
-            "stream-to-pull-stream": "1.7.2"
-          }
-        }
-      }
-    },
-    "ssb-client": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/ssb-client/-/ssb-client-4.5.2.tgz",
-      "integrity": "sha1-aBnyPwrBz/O6MfOsr0NAzG6SwZ8=",
-      "requires": {
-        "explain-error": "1.0.4",
-        "multicb": "1.2.2",
-        "multiserver": "1.10.1",
-        "muxrpc": "6.4.0",
-        "pull-hash": "1.0.0",
-        "pull-stream": "3.6.1",
-        "ssb-config": "2.2.0",
-        "ssb-keys": "7.0.13"
-      }
-    },
-    "ssb-config": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/ssb-config/-/ssb-config-2.2.0.tgz",
-      "integrity": "sha1-QcrQOKhXWvQGLT/VfTsWe+hbA7w=",
-      "requires": {
-        "deep-extend": "0.4.2",
-        "non-private-ip": "1.4.2",
-        "os-homedir": "1.0.2",
-        "rc": "1.2.4"
-      },
-      "dependencies": {
-        "non-private-ip": {
-          "version": "1.4.2",
-          "resolved": "https://registry.npmjs.org/non-private-ip/-/non-private-ip-1.4.2.tgz",
-          "integrity": "sha1-7VH6e/fpGpxjI5TxBUe2o5Xovq0=",
-          "requires": {
-            "ip": "0.3.3"
-          }
-        }
-      }
-    },
-    "ssb-friends": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/ssb-friends/-/ssb-friends-2.4.0.tgz",
-      "integrity": "sha1-DUDNlqEvIznJBkqK0dWnE+kcV64=",
-      "requires": {
-        "flumeview-reduce": "1.3.12",
-        "graphreduce": "3.0.4",
-        "obv": "0.0.1",
-        "pull-cont": "0.1.1",
-        "pull-flatmap": "0.0.1",
-        "pull-stream": "3.6.1",
-        "ssb-ref": "2.9.1"
-      },
-      "dependencies": {
-        "pull-cont": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/pull-cont/-/pull-cont-0.1.1.tgz",
-          "integrity": "sha1-3x1YDicXV7qay666IN4kIdZg1hg="
-        }
+        "ssb-social-index": "^1.0.0"
       }
     },
     "ssb-keys": {
-      "version": "7.0.13",
-      "resolved": "https://registry.npmjs.org/ssb-keys/-/ssb-keys-7.0.13.tgz",
-      "integrity": "sha1-nWUnEAWHawfOqie3JICPDGAQu8k=",
+      "version": "7.1.7",
+      "resolved": "https://registry.npmjs.org/ssb-keys/-/ssb-keys-7.1.7.tgz",
+      "integrity": "sha512-Zncn++gtpoF4Wjz/po4Jvt7mCHbQfU6ATljahqf1CprWAio4JBUJnQrUeUlmlTn3f4Tseo0/hoh3vk7Bu6M/Sw==",
       "requires": {
-        "chloride": "2.2.8",
-        "mkdirp": "0.5.1",
-        "private-box": "0.2.1"
-      }
-    },
-    "ssb-links": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/ssb-links/-/ssb-links-3.0.1.tgz",
-      "integrity": "sha1-v4UzTvR/buhIunxMb56WOmNzb28=",
-      "requires": {
-        "flumeview-query": "4.0.1",
-        "map-filter-reduce": "2.2.1",
-        "pull-stream": "3.6.1",
-        "ssb-msgs": "5.2.0"
-      }
-    },
-    "ssb-msgs": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ssb-msgs/-/ssb-msgs-5.2.0.tgz",
-      "integrity": "sha1-xoHaXNcMV0ySLcpPA8UhU4E1wkM=",
-      "requires": {
-        "ssb-ref": "2.9.1"
-      }
-    },
-    "ssb-query": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/ssb-query/-/ssb-query-1.0.2.tgz",
-      "integrity": "sha1-uFZH3vSG51cGehEqr2PqHPx0cTM=",
-      "requires": {
-        "explain-error": "1.0.4",
-        "flumeview-query": "4.0.1",
-        "pull-stream": "3.6.1"
+        "chloride": "^2.2.8",
+        "mkdirp": "~0.5.0",
+        "private-box": "^0.3.0"
       }
     },
     "ssb-ref": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/ssb-ref/-/ssb-ref-2.9.1.tgz",
-      "integrity": "sha1-YIYXE9gMERqaUq6DCZ4zGvzbv2s=",
+      "version": "2.13.9",
+      "resolved": "https://registry.npmjs.org/ssb-ref/-/ssb-ref-2.13.9.tgz",
+      "integrity": "sha512-TfatNqLvoP+eW/pMIbCmNcaoDq4R2k8jCtWkwDKx4AtluN/LwtyP931d5Mh+2gmzA04W7kxkr6f5ENGgdadMYg==",
+      "dev": true,
       "requires": {
-        "ip": "1.1.5",
-        "is-valid-domain": "0.0.5"
+        "ip": "^1.1.3",
+        "is-canonical-base64": "^1.1.1",
+        "is-valid-domain": "~0.0.1",
+        "multiserver-address": "^1.0.1"
+      }
+    },
+    "ssb-server": {
+      "version": "15.0.2",
+      "resolved": "https://registry.npmjs.org/ssb-server/-/ssb-server-15.0.2.tgz",
+      "integrity": "sha512-xY3H+E3P5vSQREtoBohUT/1Lhx01NNTkooud29h+fhwXX1+Erowds/b0M+HpVpVClY8/yR4/0jATBg0oKvD+VA==",
+      "requires": {
+        "bash-color": "~0.0.3",
+        "broadcast-stream": "^0.2.1",
+        "cont": "~1.0.3",
+        "cross-spawn": "^6.0.5",
+        "debug": "^4.1.1",
+        "deep-equal": "^1.0.1",
+        "explain-error": "^1.0.3",
+        "has-network": "0.0.1",
+        "ip": "^1.1.5",
+        "mdmanifest": "^1.0.8",
+        "minimist": "^1.1.3",
+        "mkdirp": "~0.5.0",
+        "multiblob": "^1.13.0",
+        "multiserver": "^3.3.1",
+        "multiserver-address": "^1.0.1",
+        "muxrpc-validation": "^3",
+        "muxrpcli": "3",
+        "mv": "^2.1.1",
+        "osenv": "^0.1.5",
+        "pull-cat": "~1.1.5",
+        "pull-file": "^1.0.0",
+        "pull-many": "~1.0.6",
+        "pull-pushable": "^2.2.0",
+        "pull-stream": "^3.6.2",
+        "rimraf": "^2.4.2",
+        "secret-stack": "^6.0.2",
+        "ssb-blobs": "1.2.1",
+        "ssb-caps": "^1.0.1",
+        "ssb-client": "^4.7.5",
+        "ssb-config": "^3.2.5",
+        "ssb-db": "19.2.0",
+        "ssb-ebt": "^5.6.1",
+        "ssb-friends": "^4.1.0",
+        "ssb-gossip": "^1.1.0",
+        "ssb-invite": "^2.1.2",
+        "ssb-keys": "^7.1.1",
+        "ssb-links": "^3.0.4",
+        "ssb-local": "^1.0.0",
+        "ssb-logging": "^1.0.0",
+        "ssb-master": "^1.0.2",
+        "ssb-no-auth": "^1.0.0",
+        "ssb-onion": "^1.0.0",
+        "ssb-ooo": "^1.3.0",
+        "ssb-plugins": "1.0.0",
+        "ssb-query": "^2.4.0",
+        "ssb-ref": "^2.13.9",
+        "ssb-replicate": "^1.3.0",
+        "ssb-unix-socket": "^1.0.0",
+        "ssb-ws": "^6.2.1",
+        "stream-to-pull-stream": "^1.6.10",
+        "zerr": "^1.0.0"
       },
       "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
+          "integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
+          "requires": {
+            "@babel/highlight": "^7.0.0"
+          }
+        },
+        "@babel/generator": {
+          "version": "7.4.4",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.4.4.tgz",
+          "integrity": "sha512-53UOLK6TVNqKxf7RUh8NE851EHRxOOeVXKbK2bivdb+iziMyk03Sr4eaE9OELCbyZAAafAKPDwF2TPUES5QbxQ==",
+          "requires": {
+            "@babel/types": "^7.4.4",
+            "jsesc": "^2.5.1",
+            "lodash": "^4.17.11",
+            "source-map": "^0.5.0",
+            "trim-right": "^1.0.1"
+          }
+        },
+        "@babel/helper-function-name": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
+          "integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
+          "requires": {
+            "@babel/helper-get-function-arity": "^7.0.0",
+            "@babel/template": "^7.1.0",
+            "@babel/types": "^7.0.0"
+          }
+        },
+        "@babel/helper-get-function-arity": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
+          "integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
+          "requires": {
+            "@babel/types": "^7.0.0"
+          }
+        },
+        "@babel/helper-split-export-declaration": {
+          "version": "7.4.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
+          "integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
+          "requires": {
+            "@babel/types": "^7.4.4"
+          }
+        },
+        "@babel/highlight": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
+          "integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
+          "requires": {
+            "chalk": "^2.0.0",
+            "esutils": "^2.0.2",
+            "js-tokens": "^4.0.0"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "3.2.1",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+              "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+              "requires": {
+                "color-convert": "^1.9.0"
+              }
+            },
+            "chalk": {
+              "version": "2.4.2",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+              "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+              "requires": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+              }
+            },
+            "supports-color": {
+              "version": "5.5.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+              "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+              "requires": {
+                "has-flag": "^3.0.0"
+              }
+            }
+          }
+        },
+        "@babel/parser": {
+          "version": "7.4.4",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.4.tgz",
+          "integrity": "sha512-5pCS4mOsL+ANsFZGdvNLybx4wtqAZJ0MJjMHxvzI3bvIsz6sQvzW8XX92EYIkiPtIvcfG3Aj+Ir5VNyjnZhP7w=="
+        },
+        "@babel/template": {
+          "version": "7.4.4",
+          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.4.tgz",
+          "integrity": "sha512-CiGzLN9KgAvgZsnivND7rkA+AeJ9JB0ciPOD4U59GKbQP2iQl+olF1l76kJOupqidozfZ32ghwBEJDhnk9MEcw==",
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "@babel/parser": "^7.4.4",
+            "@babel/types": "^7.4.4"
+          }
+        },
+        "@babel/traverse": {
+          "version": "7.4.4",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.4.4.tgz",
+          "integrity": "sha512-Gw6qqkw/e6AGzlyj9KnkabJX7VcubqPtkUQVAwkc0wUMldr3A/hezNB3Rc5eIvId95iSGkGIOe5hh1kMKf951A==",
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "@babel/generator": "^7.4.4",
+            "@babel/helper-function-name": "^7.1.0",
+            "@babel/helper-split-export-declaration": "^7.4.4",
+            "@babel/parser": "^7.4.4",
+            "@babel/types": "^7.4.4",
+            "debug": "^4.1.0",
+            "globals": "^11.1.0",
+            "lodash": "^4.17.11"
+          }
+        },
+        "@babel/types": {
+          "version": "7.4.4",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.4.tgz",
+          "integrity": "sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==",
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.11",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
+        "abstract-leveldown": {
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-6.0.3.tgz",
+          "integrity": "sha512-jzewKKpZbaYUa6HTThnrl+GrJhzjEAeuc7hTVpZdzg7kupXZFoqQDFwyOwLNbmJKJlmzw8yiipMPkDiuKkT06Q==",
+          "requires": {
+            "level-concat-iterator": "~2.0.0",
+            "xtend": "~4.0.0"
+          }
+        },
+        "aligned-block-file": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/aligned-block-file/-/aligned-block-file-1.2.2.tgz",
+          "integrity": "sha512-2Sy0hWhifVb8ycNFJgicL8fDPL2Ct1r62XOVxXnykn36z22MPZwnQlCmB2viQlY/lwfuO67GaQjUZ0rJgdVP7Q==",
+          "requires": {
+            "hashlru": "^2.1.0",
+            "int53": "^1.0.0",
+            "mkdirp": "^0.5.1",
+            "obv": "^0.0.1",
+            "rwlock": "^5.0.0",
+            "uint48be": "^2.0.1"
+          }
+        },
+        "ansi-escapes": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+          "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4="
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+        },
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+        },
+        "anymatch": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
+          "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
+          "requires": {
+            "micromatch": "^2.1.5",
+            "normalize-path": "^2.0.0"
+          }
+        },
+        "append-batch": {
+          "version": "0.0.2",
+          "resolved": "https://registry.npmjs.org/append-batch/-/append-batch-0.0.2.tgz",
+          "integrity": "sha1-1zm0UDiIJF1Hkz1HVisRSf+d+Lc="
+        },
+        "arr-diff": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+          "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+          "requires": {
+            "arr-flatten": "^1.0.1"
+          }
+        },
+        "arr-flatten": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+          "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
+        },
+        "arr-union": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+          "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
+        },
+        "array-find-index": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
+          "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E="
+        },
+        "array-union": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+          "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+          "requires": {
+            "array-uniq": "^1.0.1"
+          }
+        },
+        "array-uniq": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+          "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY="
+        },
+        "array-unique": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+          "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
+        },
+        "arrify": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+          "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
+        },
+        "assign-symbols": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
+          "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c="
+        },
+        "async-each": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz",
+          "integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ=="
+        },
+        "async-single": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/async-single/-/async-single-1.0.5.tgz",
+          "integrity": "sha1-El3QneldPqMKN4rb7QIQkhebA8k="
+        },
+        "async-write": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/async-write/-/async-write-2.1.0.tgz",
+          "integrity": "sha1-HnYoF9hJzkS/rAeSWkIDZ4cGGxU="
+        },
+        "atob": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
+          "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
+        },
+        "atomic-file": {
+          "version": "1.1.5",
+          "resolved": "https://registry.npmjs.org/atomic-file/-/atomic-file-1.1.5.tgz",
+          "integrity": "sha512-TG+5YFiaKQ6CZiSQsosGMJ/IJzwMZ4V/rSdEXlD6+DwKyv8OyeUcprq34kp4yuS6bfQYXhxBC2Vm8PWo+iKBGQ=="
+        },
+        "attach-ware": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/attach-ware/-/attach-ware-1.1.1.tgz",
+          "integrity": "sha1-KPUTk92LuL2q2XI0JRm/CWIaNaM=",
+          "requires": {
+            "unherit": "^1.0.0"
+          }
+        },
+        "bail": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/bail/-/bail-1.0.4.tgz",
+          "integrity": "sha512-S8vuDB4w6YpRhICUDET3guPlQpaJl7od94tpZ0Fvnyp+MKW/HyDTcRDck+29C9g+d/qQHnddRH3+94kZdrW0Ww=="
+        },
+        "balanced-match": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+        },
+        "base": {
+          "version": "0.11.2",
+          "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
+          "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
+          "requires": {
+            "cache-base": "^1.0.1",
+            "class-utils": "^0.3.5",
+            "component-emitter": "^1.2.1",
+            "define-property": "^1.0.0",
+            "isobject": "^3.0.1",
+            "mixin-deep": "^1.2.0",
+            "pascalcase": "^0.1.1"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+              "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+              "requires": {
+                "is-descriptor": "^1.0.0"
+              }
+            },
+            "is-accessor-descriptor": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+              "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+              "requires": {
+                "kind-of": "^6.0.0"
+              }
+            },
+            "is-data-descriptor": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+              "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+              "requires": {
+                "kind-of": "^6.0.0"
+              }
+            },
+            "is-descriptor": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+              "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+              "requires": {
+                "is-accessor-descriptor": "^1.0.0",
+                "is-data-descriptor": "^1.0.0",
+                "kind-of": "^6.0.2"
+              }
+            },
+            "isobject": {
+              "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+              "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+            },
+            "kind-of": {
+              "version": "6.0.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+              "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+            }
+          }
+        },
+        "base64-url": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/base64-url/-/base64-url-2.2.1.tgz",
+          "integrity": "sha512-RWaW1M7+pLUikK1bnGyiDe1oY2BKOtbS30Ua1pSAH41st59qDxi/XiggjVhHVPIejXY1eqJ21W3uxHtZpM6KQw=="
+        },
+        "bash-color": {
+          "version": "0.0.4",
+          "resolved": "https://registry.npmjs.org/bash-color/-/bash-color-0.0.4.tgz",
+          "integrity": "sha1-6b6M4zVAytpIgXaMWb1jhlc26RM="
+        },
+        "binary-extensions": {
+          "version": "1.13.1",
+          "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
+          "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw=="
+        },
+        "binary-search": {
+          "version": "1.3.5",
+          "resolved": "https://registry.npmjs.org/binary-search/-/binary-search-1.3.5.tgz",
+          "integrity": "sha512-RHFP0AdU6KAB0CCZsRMU2CJTk2EpL8GLURT+4gilpjr1f/7M91FgUMnXuQLmf3OKLet34gjuNFwO7e4agdX5pw=="
+        },
+        "bl": {
+          "version": "0.8.2",
+          "resolved": "https://registry.npmjs.org/bl/-/bl-0.8.2.tgz",
+          "integrity": "sha1-yba8oI0bwuoA/Ir7Txpf0eHGbk4=",
+          "requires": {
+            "readable-stream": "~1.0.26"
+          },
+          "dependencies": {
+            "isarray": {
+              "version": "0.0.1",
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+              "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+            },
+            "readable-stream": {
+              "version": "1.0.34",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+              "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.1",
+                "isarray": "0.0.1",
+                "string_decoder": "~0.10.x"
+              }
+            },
+            "string_decoder": {
+              "version": "0.10.31",
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+              "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+            }
+          }
+        },
+        "blake2s": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/blake2s/-/blake2s-1.1.0.tgz",
+          "integrity": "sha1-glqPxTal3EMZNGfzEk9+m3iyHO8="
+        },
+        "brace-expansion": {
+          "version": "1.1.11",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+          "requires": {
+            "balanced-match": "^1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "braces": {
+          "version": "1.8.5",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+          "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+          "requires": {
+            "expand-range": "^1.8.1",
+            "preserve": "^0.2.0",
+            "repeat-element": "^1.1.2"
+          }
+        },
+        "broadcast-stream": {
+          "version": "0.2.2",
+          "resolved": "https://registry.npmjs.org/broadcast-stream/-/broadcast-stream-0.2.2.tgz",
+          "integrity": "sha1-eee7FKmrunf3KsklgiAkKo/TkZ0="
+        },
+        "buffer-from": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+          "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
+        },
+        "bytewise": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/bytewise/-/bytewise-1.1.0.tgz",
+          "integrity": "sha1-HRPL/3F65xWAlKqIGzXQgbOHJT4=",
+          "requires": {
+            "bytewise-core": "^1.2.2",
+            "typewise": "^1.0.3"
+          }
+        },
+        "bytewise-core": {
+          "version": "1.2.3",
+          "resolved": "https://registry.npmjs.org/bytewise-core/-/bytewise-core-1.2.3.tgz",
+          "integrity": "sha1-P7QQx+kVWOsasiqCg0V3qmvWHUI=",
+          "requires": {
+            "typewise-core": "^1.2"
+          }
+        },
+        "cache-base": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
+          "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
+          "requires": {
+            "collection-visit": "^1.0.0",
+            "component-emitter": "^1.2.1",
+            "get-value": "^2.0.6",
+            "has-value": "^1.0.0",
+            "isobject": "^3.0.1",
+            "set-value": "^2.0.0",
+            "to-object-path": "^0.3.0",
+            "union-value": "^1.0.0",
+            "unset-value": "^1.0.0"
+          },
+          "dependencies": {
+            "isobject": {
+              "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+              "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+            }
+          }
+        },
+        "camelcase": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+          "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
+        },
+        "camelcase-keys": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-4.2.0.tgz",
+          "integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
+          "requires": {
+            "camelcase": "^4.1.0",
+            "map-obj": "^2.0.0",
+            "quick-lru": "^1.0.0"
+          },
+          "dependencies": {
+            "camelcase": {
+              "version": "4.1.0",
+              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+              "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+            }
+          }
+        },
+        "cat-names": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/cat-names/-/cat-names-2.0.0.tgz",
+          "integrity": "sha512-yjcTHwA7tcro823P5yIfmTvXT8p5YxJd4eASWHAHvqaekuJoGu1qjWoldgfV2mH4tgLp+FNAf13uiDEo/O7LGg==",
+          "requires": {
+            "meow": "^5.0.0",
+            "unique-random-array": "^1.0.0"
+          }
+        },
+        "ccount": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/ccount/-/ccount-1.0.4.tgz",
+          "integrity": "sha512-fpZ81yYfzentuieinmGnphk0pLkOTMm6MZdVqwd77ROvhko6iujLNGrHH5E7utq3ygWklwfmwuG+A7P+NpqT6w=="
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          }
+        },
+        "character-entities": {
+          "version": "1.2.3",
+          "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.3.tgz",
+          "integrity": "sha512-yB4oYSAa9yLcGyTbB4ItFwHw43QHdH129IJ5R+WvxOkWlyFnR5FAaBNnUq4mcxsTVZGh28bHoeTHMKXH1wZf3w=="
+        },
+        "character-entities-html4": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-1.1.3.tgz",
+          "integrity": "sha512-SwnyZ7jQBCRHELk9zf2CN5AnGEc2nA+uKMZLHvcqhpPprjkYhiLn0DywMHgN5ttFZuITMATbh68M6VIVKwJbcg=="
+        },
+        "character-entities-legacy": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.3.tgz",
+          "integrity": "sha512-YAxUpPoPwxYFsslbdKkhrGnXAtXoHNgYjlBM3WMXkWGTl5RsY3QmOyhwAgL8Nxm9l5LBThXGawxKPn68y6/fww=="
+        },
+        "character-reference-invalid": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.3.tgz",
+          "integrity": "sha512-VOq6PRzQBam/8Jm6XBGk2fNEnHXAdGd6go0rtd4weAGECBamHDwwCQSOT12TACIYUZegUXnV6xBXqUssijtxIg=="
+        },
+        "charwise": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/charwise/-/charwise-3.0.1.tgz",
+          "integrity": "sha512-RcdumNsM6fJZ5HHbYunqj2bpurVRGsXour3OR+SlLEHFhG6ALm54i6Osnh+OvO7kEoSBzwExpblYFH8zKQiEPw=="
+        },
+        "chloride": {
+          "version": "2.2.14",
+          "resolved": "https://registry.npmjs.org/chloride/-/chloride-2.2.14.tgz",
+          "integrity": "sha512-Jp3kpDIO4MlcJCFi4jER9P7k3sAVvIwbe4QJtM9Nkp43e/GQ/98HU1wJS6NdU6cbzfGrKWmMdRB+VNRrCynzfw==",
+          "requires": {
+            "is-electron": "^2.2.0",
+            "sodium-browserify": "^1.2.7",
+            "sodium-browserify-tweetnacl": "^0.2.5",
+            "sodium-chloride": "^1.1.2",
+            "sodium-native": "^2.1.6"
+          }
+        },
+        "chloride-test": {
+          "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/chloride-test/-/chloride-test-1.2.4.tgz",
+          "integrity": "sha512-9vhoi1qXSBPn6//ZxIgSe3M2QhKHzIPZQzmrZgmPADsqW0Jxpe3db1e7aGSRUMXbxAQ04SfypdT8dGaSvIvKDw==",
+          "requires": {
+            "json-buffer": "^2.0.11"
+          }
+        },
+        "chokidar": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
+          "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
+          "requires": {
+            "anymatch": "^1.3.0",
+            "async-each": "^1.0.0",
+            "fsevents": "^1.0.0",
+            "glob-parent": "^2.0.0",
+            "inherits": "^2.0.1",
+            "is-binary-path": "^1.0.0",
+            "is-glob": "^2.0.0",
+            "path-is-absolute": "^1.0.0",
+            "readdirp": "^2.0.0"
+          }
+        },
+        "class-utils": {
+          "version": "0.3.6",
+          "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
+          "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
+          "requires": {
+            "arr-union": "^3.1.0",
+            "define-property": "^0.2.5",
+            "isobject": "^3.0.0",
+            "static-extend": "^0.1.1"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "0.2.5",
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+              "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+              "requires": {
+                "is-descriptor": "^0.1.0"
+              }
+            },
+            "isobject": {
+              "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+              "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+            }
+          }
+        },
+        "cli-cursor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
+          "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+          "requires": {
+            "restore-cursor": "^1.0.1"
+          }
+        },
+        "co": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/co/-/co-3.1.0.tgz",
+          "integrity": "sha1-TqVOpaCJOBUxheFSEMaNkJK8G3g="
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+        },
+        "collapse-white-space": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-1.0.5.tgz",
+          "integrity": "sha512-703bOOmytCYAX9cXYqoikYIx6twmFCXsnzRQheBcTG3nzKYBR4P/+wkYeH+Mvj7qUz8zZDtdyzbxfnEi/kYzRQ=="
+        },
+        "collection-visit": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
+          "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+          "requires": {
+            "map-visit": "^1.0.0",
+            "object-visit": "^1.0.0"
+          }
+        },
+        "color-convert": {
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+        },
+        "commander": {
+          "version": "2.20.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
+          "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ=="
+        },
+        "compare-at-paths": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/compare-at-paths/-/compare-at-paths-1.0.0.tgz",
+          "integrity": "sha512-Ke1ejo/RZ+Hzku4gcW34uPMOR4Cpq87MAotELgV9mwiAzDN726cu+eWo0zWg1vRIfyf6yK5bW9uIW+c/SksQ5w==",
+          "requires": {
+            "libnested": "^1.3.2",
+            "tape": "^4.9.1",
+            "typewiselite": "^1.0.0"
+          }
+        },
+        "compatibility": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/compatibility/-/compatibility-1.0.0.tgz",
+          "integrity": "sha512-SJztBRqXAddo8gBxYjXLgvLvdCveuTNzDhNl7layXezAmHUIt2JKTCGZjUsVukFNowFI108TT3T3dbvBA5+bXg==",
+          "requires": {
+            "debug": "^4.1.1",
+            "npm-install-package": "^2.1.0",
+            "semver": "^6.1.0"
+          },
+          "dependencies": {
+            "semver": {
+              "version": "6.1.0",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-6.1.0.tgz",
+              "integrity": "sha512-kCqEOOHoBcFs/2Ccuk4Xarm/KiWRSLEX9CAZF8xkJ6ZPlIoTZ8V5f7J16vYLJqDbR7KrxTJpR2lqjIEm2Qx9cQ=="
+            }
+          }
+        },
+        "component-emitter": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
+          "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg=="
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+        },
+        "concat-stream": {
+          "version": "1.6.2",
+          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+          "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+          "requires": {
+            "buffer-from": "^1.0.0",
+            "inherits": "^2.0.3",
+            "readable-stream": "^2.2.2",
+            "typedarray": "^0.0.6"
+          }
+        },
+        "cont": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/cont/-/cont-1.0.3.tgz",
+          "integrity": "sha1-aHTx6TX8qZ0EjK6qrZoK6wILzOA=",
+          "requires": {
+            "continuable": "~1.2.0",
+            "continuable-para": "~1.2.0",
+            "continuable-series": "~1.2.0"
+          }
+        },
+        "continuable": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/continuable/-/continuable-1.2.0.tgz",
+          "integrity": "sha1-CCd0aNQRNiAAdMz4cpQwjRafJbY="
+        },
+        "continuable-hash": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/continuable-hash/-/continuable-hash-0.1.4.tgz",
+          "integrity": "sha1-gcdNQXcdjJJ4Ph4A5fEbNNbfx4w=",
+          "requires": {
+            "continuable": "~1.1.6"
+          },
+          "dependencies": {
+            "continuable": {
+              "version": "1.1.8",
+              "resolved": "https://registry.npmjs.org/continuable/-/continuable-1.1.8.tgz",
+              "integrity": "sha1-3Id7R0FghwrjvN6HM2Jo6+UFl9U="
+            }
+          }
+        },
+        "continuable-list": {
+          "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/continuable-list/-/continuable-list-0.1.6.tgz",
+          "integrity": "sha1-h88G7FgHFuEN/5X7C4TF8OisrF8=",
+          "requires": {
+            "continuable": "~1.1.6"
+          },
+          "dependencies": {
+            "continuable": {
+              "version": "1.1.8",
+              "resolved": "https://registry.npmjs.org/continuable/-/continuable-1.1.8.tgz",
+              "integrity": "sha1-3Id7R0FghwrjvN6HM2Jo6+UFl9U="
+            }
+          }
+        },
+        "continuable-para": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/continuable-para/-/continuable-para-1.2.0.tgz",
+          "integrity": "sha1-RFUQ9klFndD8NchyAVFGEicxxYM=",
+          "requires": {
+            "continuable-hash": "~0.1.4",
+            "continuable-list": "~0.1.5"
+          }
+        },
+        "continuable-series": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/continuable-series/-/continuable-series-1.2.0.tgz",
+          "integrity": "sha1-MkM5euk6cdZVswJoNKUVkLlYueg="
+        },
+        "copy-descriptor": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
+          "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+        },
+        "cross-spawn": {
+          "version": "6.0.5",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+          "requires": {
+            "nice-try": "^1.0.4",
+            "path-key": "^2.0.1",
+            "semver": "^5.5.0",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
+        },
+        "currently-unhandled": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
+          "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
+          "requires": {
+            "array-find-index": "^1.0.1"
+          }
+        },
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "decamelize": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+          "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+        },
+        "decamelize-keys": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
+          "integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
+          "requires": {
+            "decamelize": "^1.1.0",
+            "map-obj": "^1.0.0"
+          },
+          "dependencies": {
+            "map-obj": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+              "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0="
+            }
+          }
+        },
+        "decode-uri-component": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+          "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
+        },
+        "deep-equal": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+          "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU="
+        },
+        "deep-extend": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+          "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
+        },
+        "deferred-leveldown": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-5.0.1.tgz",
+          "integrity": "sha512-BXohsvTedWOLkj2n/TY+yqVlrCWa2Zs8LSxh3uCAgFOru7/pjxKyZAexGa1j83BaKloER4PqUyQ9rGPJLt9bqA==",
+          "requires": {
+            "abstract-leveldown": "~6.0.0",
+            "inherits": "^2.0.3"
+          }
+        },
+        "define-properties": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+          "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+          "requires": {
+            "object-keys": "^1.0.12"
+          }
+        },
+        "define-property": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
+          "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+          "requires": {
+            "is-descriptor": "^1.0.2",
+            "isobject": "^3.0.1"
+          },
+          "dependencies": {
+            "is-accessor-descriptor": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+              "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+              "requires": {
+                "kind-of": "^6.0.0"
+              }
+            },
+            "is-data-descriptor": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+              "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+              "requires": {
+                "kind-of": "^6.0.0"
+              }
+            },
+            "is-descriptor": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+              "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+              "requires": {
+                "is-accessor-descriptor": "^1.0.0",
+                "is-data-descriptor": "^1.0.0",
+                "kind-of": "^6.0.2"
+              }
+            },
+            "isobject": {
+              "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+              "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+            },
+            "kind-of": {
+              "version": "6.0.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+              "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+            }
+          }
+        },
+        "defined": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+          "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM="
+        },
+        "detab": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/detab/-/detab-1.0.2.tgz",
+          "integrity": "sha1-AbwqSr57x8xnwwOYCO265HBJoO4=",
+          "requires": {
+            "repeat-string": "^1.5.2"
+          }
+        },
+        "discontinuous-range": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
+          "integrity": "sha1-44Mx8IRLukm5qctxx3FYWqsbxlo="
+        },
+        "dog-names": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/dog-names/-/dog-names-1.0.2.tgz",
+          "integrity": "sha1-udoTXkxAlsxzcJ770K9V07YFv0g=",
+          "requires": {
+            "meow": "^3.0.0",
+            "unique-random-array": "^1.0.0"
+          },
+          "dependencies": {
+            "camelcase-keys": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+              "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
+              "requires": {
+                "camelcase": "^2.0.0",
+                "map-obj": "^1.0.0"
+              }
+            },
+            "find-up": {
+              "version": "1.1.2",
+              "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+              "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+              "requires": {
+                "path-exists": "^2.0.0",
+                "pinkie-promise": "^2.0.0"
+              }
+            },
+            "indent-string": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
+              "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
+              "requires": {
+                "repeating": "^2.0.0"
+              }
+            },
+            "load-json-file": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+              "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+              "requires": {
+                "graceful-fs": "^4.1.2",
+                "parse-json": "^2.2.0",
+                "pify": "^2.0.0",
+                "pinkie-promise": "^2.0.0",
+                "strip-bom": "^2.0.0"
+              }
+            },
+            "map-obj": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+              "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0="
+            },
+            "meow": {
+              "version": "3.7.0",
+              "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+              "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
+              "requires": {
+                "camelcase-keys": "^2.0.0",
+                "decamelize": "^1.1.2",
+                "loud-rejection": "^1.0.0",
+                "map-obj": "^1.0.1",
+                "minimist": "^1.1.3",
+                "normalize-package-data": "^2.3.4",
+                "object-assign": "^4.0.1",
+                "read-pkg-up": "^1.0.1",
+                "redent": "^1.0.0",
+                "trim-newlines": "^1.0.0"
+              }
+            },
+            "parse-json": {
+              "version": "2.2.0",
+              "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+              "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+              "requires": {
+                "error-ex": "^1.2.0"
+              }
+            },
+            "path-exists": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+              "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+              "requires": {
+                "pinkie-promise": "^2.0.0"
+              }
+            },
+            "path-type": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+              "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+              "requires": {
+                "graceful-fs": "^4.1.2",
+                "pify": "^2.0.0",
+                "pinkie-promise": "^2.0.0"
+              }
+            },
+            "read-pkg": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+              "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+              "requires": {
+                "load-json-file": "^1.0.0",
+                "normalize-package-data": "^2.3.2",
+                "path-type": "^1.0.0"
+              }
+            },
+            "read-pkg-up": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+              "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+              "requires": {
+                "find-up": "^1.0.0",
+                "read-pkg": "^1.0.0"
+              }
+            },
+            "redent": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
+              "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
+              "requires": {
+                "indent-string": "^2.1.0",
+                "strip-indent": "^1.0.1"
+              }
+            },
+            "strip-bom": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+              "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+              "requires": {
+                "is-utf8": "^0.2.0"
+              }
+            },
+            "strip-indent": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
+              "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
+              "requires": {
+                "get-stdin": "^4.0.1"
+              }
+            },
+            "trim-newlines": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
+              "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM="
+            }
+          }
+        },
+        "dynamic-dijkstra": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/dynamic-dijkstra/-/dynamic-dijkstra-1.0.2.tgz",
+          "integrity": "sha512-1N+eCCrepIeK1+qtWrMEO1CV68Hn+TLbiR9c70VB3xnut3DmUxT+3T7sRHhb0mpK2F/74IfP+loQDriU2W9lkA==",
+          "requires": {
+            "heap": "^0.2.6",
+            "rng": "^0.2.2"
+          }
+        },
+        "ed2curve": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/ed2curve/-/ed2curve-0.1.4.tgz",
+          "integrity": "sha1-lKRCSLuH2jXbDv968KpXYWgRf1k=",
+          "requires": {
+            "tweetnacl": "0.x.x"
+          }
+        },
+        "elegant-spinner": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/elegant-spinner/-/elegant-spinner-1.0.1.tgz",
+          "integrity": "sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4="
+        },
+        "emoji-named-characters": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/emoji-named-characters/-/emoji-named-characters-1.0.2.tgz",
+          "integrity": "sha1-zes20OZgAsS5178d+8Ohmft9QJs="
+        },
+        "emoji-server": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-server/-/emoji-server-1.0.0.tgz",
+          "integrity": "sha1-0GPP7prxGMxa7vvC6bPdUIWBXGM=",
+          "requires": {
+            "emoji-named-characters": "~1.0.2"
+          }
+        },
+        "encoding-down": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/encoding-down/-/encoding-down-6.0.2.tgz",
+          "integrity": "sha512-oAEANslmNb64AF4kvHXjTxB7KecwD7X0qf8MffMfhpjP6gjGcnCTOkRgps/1yUNeR4Bhe6ckN6aAzZz+RIYgTw==",
+          "requires": {
+            "abstract-leveldown": "^6.0.0",
+            "inherits": "^2.0.3",
+            "level-codec": "^9.0.0",
+            "level-errors": "^2.0.0"
+          }
+        },
+        "epidemic-broadcast-trees": {
+          "version": "6.3.5",
+          "resolved": "https://registry.npmjs.org/epidemic-broadcast-trees/-/epidemic-broadcast-trees-6.3.5.tgz",
+          "integrity": "sha512-FYCOslXU7OBkz8A9FXsykcpgby3WKcRdLTCr1LivLLSU2nzaO/x86jBGNFEZkezZPx9/Z5fDVX8SGQyXLz8WZQ==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "push-stream": "^10.0.0"
+          }
+        },
+        "errno": {
+          "version": "0.1.7",
+          "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
+          "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
+          "requires": {
+            "prr": "~1.0.1"
+          }
+        },
+        "error-ex": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+          "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+          "requires": {
+            "is-arrayish": "^0.2.1"
+          }
+        },
+        "es-abstract": {
+          "version": "1.13.0",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.13.0.tgz",
+          "integrity": "sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==",
+          "requires": {
+            "es-to-primitive": "^1.2.0",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "is-callable": "^1.1.4",
+            "is-regex": "^1.0.4",
+            "object-keys": "^1.0.12"
+          }
+        },
+        "es-to-primitive": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
+          "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
+          "requires": {
+            "is-callable": "^1.1.4",
+            "is-date-object": "^1.0.1",
+            "is-symbol": "^1.0.2"
+          }
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+        },
+        "esutils": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+          "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+        },
+        "exit-hook": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
+          "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g="
+        },
+        "expand-brackets": {
+          "version": "0.1.5",
+          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+          "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+          "requires": {
+            "is-posix-bracket": "^0.1.0"
+          }
+        },
+        "expand-range": {
+          "version": "1.8.2",
+          "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+          "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+          "requires": {
+            "fill-range": "^2.1.0"
+          }
+        },
+        "explain-error": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/explain-error/-/explain-error-1.0.4.tgz",
+          "integrity": "sha1-p5PTrAytTGq1cemWj7urbLJTKSk="
+        },
+        "extend": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+          "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+        },
+        "extend-shallow": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+          "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+          "requires": {
+            "assign-symbols": "^1.0.0",
+            "is-extendable": "^1.0.1"
+          },
+          "dependencies": {
+            "is-extendable": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+              "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+              "requires": {
+                "is-plain-object": "^2.0.4"
+              }
+            }
+          }
+        },
+        "extend.js": {
+          "version": "0.0.2",
+          "resolved": "https://registry.npmjs.org/extend.js/-/extend.js-0.0.2.tgz",
+          "integrity": "sha1-D5x6gaHyCLcD6wwxMf5XFqxuzRU="
+        },
+        "extglob": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+          "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+          "requires": {
+            "is-extglob": "^1.0.0"
+          }
+        },
+        "fast-future": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/fast-future/-/fast-future-1.0.2.tgz",
+          "integrity": "sha1-hDWpqqAteSSNF9cE52JZMB2ZKAo="
+        },
+        "filename-regex": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
+          "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY="
+        },
+        "fill-range": {
+          "version": "2.2.4",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
+          "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
+          "requires": {
+            "is-number": "^2.1.0",
+            "isobject": "^2.0.0",
+            "randomatic": "^3.0.0",
+            "repeat-element": "^1.1.2",
+            "repeat-string": "^1.5.2"
+          }
+        },
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "requires": {
+            "locate-path": "^2.0.0"
+          }
+        },
+        "flumecodec": {
+          "version": "0.0.0",
+          "resolved": "https://registry.npmjs.org/flumecodec/-/flumecodec-0.0.0.tgz",
+          "integrity": "sha1-Ns4Gq+Lg4BxE3WnyoWUwWiMgZJs=",
+          "requires": {
+            "level-codec": "^6.2.0"
+          },
+          "dependencies": {
+            "level-codec": {
+              "version": "6.2.0",
+              "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-6.2.0.tgz",
+              "integrity": "sha1-pLUkS7akwvcj1oodZOmAxTYn2dQ="
+            }
+          }
+        },
+        "flumedb": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/flumedb/-/flumedb-1.1.0.tgz",
+          "integrity": "sha512-Bwol+72GU5z2DxZlnaxUA9A8qaRcQcdTprmRcgfqn2ldn147ByVh9Zyp90hVGPlo/oEN/yjOBUXcNkK3SYjbgA==",
+          "requires": {
+            "cont": "^1.0.3",
+            "explain-error": "^1.0.3",
+            "obv": "0.0.1",
+            "pull-cont": "^0.1.1",
+            "pull-looper": "^1.0.0",
+            "pull-stream": "^3.5.0"
+          }
+        },
+        "flumelog-offset": {
+          "version": "3.4.2",
+          "resolved": "https://registry.npmjs.org/flumelog-offset/-/flumelog-offset-3.4.2.tgz",
+          "integrity": "sha512-pj8gc3idzbpWjGQPXvRwNdkqtHPx/0olLsyip3u1lULP+LVvcYGYvTt8AU0frKWSFsGST0B8WVh9DrZ5rsEzbg==",
+          "requires": {
+            "aligned-block-file": "^1.2.0",
+            "append-batch": "0.0.2",
+            "hashlru": "^2.3.0",
+            "int53": "^1.0.0",
+            "looper": "^4.0.0",
+            "obv": "0.0.1",
+            "pull-cursor": "^3.0.0",
+            "pull-looper": "^1.0.0",
+            "uint48be": "^2.0.1"
+          }
+        },
+        "flumeview-hashtable": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/flumeview-hashtable/-/flumeview-hashtable-1.1.1.tgz",
+          "integrity": "sha512-73LAN0qF4zVMHMExYhK0z1swDo6FEh/bt1HF5/UnWkgI5JsECXOK2bTokWVU1levtr9bd+IxYChnJKJNnEzD0A==",
+          "requires": {
+            "async-single": "^1.0.5",
+            "atomic-file": "^1.1.3",
+            "obv": "0.0.1",
+            "pull-stream": "^3.6.0"
+          }
+        },
+        "flumeview-level": {
+          "version": "3.0.13",
+          "resolved": "https://registry.npmjs.org/flumeview-level/-/flumeview-level-3.0.13.tgz",
+          "integrity": "sha512-K8sM6AoWVGWps5H/MiqEHxWd0Ts3NtcWEsBjGmC3LD2EPOhrTcDQFn4dVpGAdiZma3RGFRVHE7OTperHrfJnkA==",
+          "requires": {
+            "charwise": "^3.0.1",
+            "explain-error": "^1.0.4",
+            "level": "^5.0.0",
+            "ltgt": "^2.1.3",
+            "mkdirp": "^0.5.1",
+            "obv": "0.0.1",
+            "pull-level": "^2.0.3",
+            "pull-paramap": "^1.2.1",
+            "pull-stream": "^3.5.0",
+            "pull-write": "^1.1.1"
+          }
+        },
+        "flumeview-query": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/flumeview-query/-/flumeview-query-6.3.0.tgz",
+          "integrity": "sha512-8QBannTFLICARmflhHpXNeR5hh6IzIyJz4XhKTofzmxq/hXEn1un7aF6P6dRQkOwthENDTbSB07eWKqwnYDKtw==",
+          "requires": {
+            "deep-equal": "^1.0.1",
+            "flumeview-level": "^3.0.0",
+            "map-filter-reduce": "^3.0.7",
+            "pull-flatmap": "0.0.1",
+            "pull-paramap": "^1.1.3",
+            "pull-sink-through": "0.0.0",
+            "pull-stream": "^3.4.0"
+          },
+          "dependencies": {
+            "map-filter-reduce": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/map-filter-reduce/-/map-filter-reduce-3.2.2.tgz",
+              "integrity": "sha512-p+NIGQbEBxlw/qWwG+NME98G/9kjOQI70hmaH8QEZtIWfTmfMYLKQW4PJChP4izPHNAxlOfv/qefP0+2ZXn84A==",
+              "requires": {
+                "binary-search": "^1.2.0",
+                "compare-at-paths": "^1.0.0",
+                "pull-sink-through": "0.0.0",
+                "pull-sort": "^1.0.1",
+                "pull-stream": "^3.4.3",
+                "typewiselite": "^1.0.0"
+              }
+            }
+          }
+        },
+        "flumeview-reduce": {
+          "version": "1.3.16",
+          "resolved": "https://registry.npmjs.org/flumeview-reduce/-/flumeview-reduce-1.3.16.tgz",
+          "integrity": "sha512-4ATidV3QARML74eNdi+HPzGa4JtSZfnQpW6QQArlKZ6NRkjax3EFLt42hK2VJyADxnVnsVInt/ItqJL/4G1/5g==",
+          "requires": {
+            "async-single": "^1.0.5",
+            "atomic-file": "^2.0.0",
+            "deep-equal": "^1.0.1",
+            "flumecodec": "0.0.0",
+            "obv": "0.0.1",
+            "pull-notify": "^0.1.1",
+            "pull-stream": "^3.5.0"
+          },
+          "dependencies": {
+            "atomic-file": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/atomic-file/-/atomic-file-2.0.0.tgz",
+              "integrity": "sha512-8acsmdYLYCzawXHRV+ryvRppE6dkkPrSywy6wiCzjp2T0wX4rzxw1tJbPgUgZPdi3OQ3AMvvZ3Anrnq6bERvLg==",
+              "requires": {
+                "flumecodec": "0.0.1",
+                "idb-kv-store": "^4.4.0"
+              },
+              "dependencies": {
+                "flumecodec": {
+                  "version": "0.0.1",
+                  "resolved": "https://registry.npmjs.org/flumecodec/-/flumecodec-0.0.1.tgz",
+                  "integrity": "sha1-rgSacUOGu4PjQmV6gpJLcDZKkNY=",
+                  "requires": {
+                    "level-codec": "^6.2.0"
+                  }
+                }
+              }
+            },
+            "level-codec": {
+              "version": "6.2.0",
+              "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-6.2.0.tgz",
+              "integrity": "sha1-pLUkS7akwvcj1oodZOmAxTYn2dQ="
+            }
+          }
+        },
+        "for-each": {
+          "version": "0.3.3",
+          "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
+          "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+          "requires": {
+            "is-callable": "^1.1.3"
+          }
+        },
+        "for-in": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+          "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
+        },
+        "for-own": {
+          "version": "0.1.5",
+          "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+          "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+          "requires": {
+            "for-in": "^1.0.1"
+          }
+        },
+        "fragment-cache": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
+          "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
+          "requires": {
+            "map-cache": "^0.2.2"
+          }
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+        },
+        "fsevents": {
+          "version": "1.2.9",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.9.tgz",
+          "integrity": "sha512-oeyj2H3EjjonWcFjD5NvZNE9Rqe4UW+nQBU2HNeKw0koVLEFIhtyETyAakeAM3de7Z/SW5kcA+fZUait9EApnw==",
+          "optional": true,
+          "requires": {
+            "nan": "^2.12.1",
+            "node-pre-gyp": "^0.12.0"
+          },
+          "dependencies": {
+            "abbrev": {
+              "version": "1.1.1",
+              "bundled": true,
+              "optional": true
+            },
+            "ansi-regex": {
+              "version": "2.1.1",
+              "bundled": true,
+              "optional": true
+            },
+            "aproba": {
+              "version": "1.2.0",
+              "bundled": true,
+              "optional": true
+            },
+            "are-we-there-yet": {
+              "version": "1.1.5",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "delegates": "^1.0.0",
+                "readable-stream": "^2.0.6"
+              }
+            },
+            "balanced-match": {
+              "version": "1.0.0",
+              "bundled": true,
+              "optional": true
+            },
+            "brace-expansion": {
+              "version": "1.1.11",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+              }
+            },
+            "chownr": {
+              "version": "1.1.1",
+              "bundled": true,
+              "optional": true
+            },
+            "code-point-at": {
+              "version": "1.1.0",
+              "bundled": true,
+              "optional": true
+            },
+            "concat-map": {
+              "version": "0.0.1",
+              "bundled": true,
+              "optional": true
+            },
+            "console-control-strings": {
+              "version": "1.1.0",
+              "bundled": true,
+              "optional": true
+            },
+            "core-util-is": {
+              "version": "1.0.2",
+              "bundled": true,
+              "optional": true
+            },
+            "debug": {
+              "version": "4.1.1",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "ms": "^2.1.1"
+              }
+            },
+            "deep-extend": {
+              "version": "0.6.0",
+              "bundled": true,
+              "optional": true
+            },
+            "delegates": {
+              "version": "1.0.0",
+              "bundled": true,
+              "optional": true
+            },
+            "detect-libc": {
+              "version": "1.0.3",
+              "bundled": true,
+              "optional": true
+            },
+            "fs-minipass": {
+              "version": "1.2.5",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "minipass": "^2.2.1"
+              }
+            },
+            "fs.realpath": {
+              "version": "1.0.0",
+              "bundled": true,
+              "optional": true
+            },
+            "gauge": {
+              "version": "2.7.4",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "aproba": "^1.0.3",
+                "console-control-strings": "^1.0.0",
+                "has-unicode": "^2.0.0",
+                "object-assign": "^4.1.0",
+                "signal-exit": "^3.0.0",
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1",
+                "wide-align": "^1.1.0"
+              }
+            },
+            "glob": {
+              "version": "7.1.3",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+              }
+            },
+            "has-unicode": {
+              "version": "2.0.1",
+              "bundled": true,
+              "optional": true
+            },
+            "iconv-lite": {
+              "version": "0.4.24",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "safer-buffer": ">= 2.1.2 < 3"
+              }
+            },
+            "ignore-walk": {
+              "version": "3.0.1",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "minimatch": "^3.0.4"
+              }
+            },
+            "inflight": {
+              "version": "1.0.6",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "once": "^1.3.0",
+                "wrappy": "1"
+              }
+            },
+            "inherits": {
+              "version": "2.0.3",
+              "bundled": true,
+              "optional": true
+            },
+            "ini": {
+              "version": "1.3.5",
+              "bundled": true,
+              "optional": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "1.0.0",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "number-is-nan": "^1.0.0"
+              }
+            },
+            "isarray": {
+              "version": "1.0.0",
+              "bundled": true,
+              "optional": true
+            },
+            "minimatch": {
+              "version": "3.0.4",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "brace-expansion": "^1.1.7"
+              }
+            },
+            "minimist": {
+              "version": "0.0.8",
+              "bundled": true,
+              "optional": true
+            },
+            "minipass": {
+              "version": "2.3.5",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "safe-buffer": "^5.1.2",
+                "yallist": "^3.0.0"
+              }
+            },
+            "minizlib": {
+              "version": "1.2.1",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "minipass": "^2.2.1"
+              }
+            },
+            "mkdirp": {
+              "version": "0.5.1",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "minimist": "0.0.8"
+              }
+            },
+            "ms": {
+              "version": "2.1.1",
+              "bundled": true,
+              "optional": true
+            },
+            "needle": {
+              "version": "2.3.0",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "debug": "^4.1.0",
+                "iconv-lite": "^0.4.4",
+                "sax": "^1.2.4"
+              }
+            },
+            "node-pre-gyp": {
+              "version": "0.12.0",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "detect-libc": "^1.0.2",
+                "mkdirp": "^0.5.1",
+                "needle": "^2.2.1",
+                "nopt": "^4.0.1",
+                "npm-packlist": "^1.1.6",
+                "npmlog": "^4.0.2",
+                "rc": "^1.2.7",
+                "rimraf": "^2.6.1",
+                "semver": "^5.3.0",
+                "tar": "^4"
+              }
+            },
+            "nopt": {
+              "version": "4.0.1",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "abbrev": "1",
+                "osenv": "^0.1.4"
+              }
+            },
+            "npm-bundled": {
+              "version": "1.0.6",
+              "bundled": true,
+              "optional": true
+            },
+            "npm-packlist": {
+              "version": "1.4.1",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "ignore-walk": "^3.0.1",
+                "npm-bundled": "^1.0.1"
+              }
+            },
+            "npmlog": {
+              "version": "4.1.2",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "are-we-there-yet": "~1.1.2",
+                "console-control-strings": "~1.1.0",
+                "gauge": "~2.7.3",
+                "set-blocking": "~2.0.0"
+              }
+            },
+            "number-is-nan": {
+              "version": "1.0.1",
+              "bundled": true,
+              "optional": true
+            },
+            "object-assign": {
+              "version": "4.1.1",
+              "bundled": true,
+              "optional": true
+            },
+            "once": {
+              "version": "1.4.0",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "wrappy": "1"
+              }
+            },
+            "os-homedir": {
+              "version": "1.0.2",
+              "bundled": true,
+              "optional": true
+            },
+            "os-tmpdir": {
+              "version": "1.0.2",
+              "bundled": true,
+              "optional": true
+            },
+            "osenv": {
+              "version": "0.1.5",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "os-homedir": "^1.0.0",
+                "os-tmpdir": "^1.0.0"
+              }
+            },
+            "path-is-absolute": {
+              "version": "1.0.1",
+              "bundled": true,
+              "optional": true
+            },
+            "process-nextick-args": {
+              "version": "2.0.0",
+              "bundled": true,
+              "optional": true
+            },
+            "rc": {
+              "version": "1.2.8",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "deep-extend": "^0.6.0",
+                "ini": "~1.3.0",
+                "minimist": "^1.2.0",
+                "strip-json-comments": "~2.0.1"
+              },
+              "dependencies": {
+                "minimist": {
+                  "version": "1.2.0",
+                  "bundled": true,
+                  "optional": true
+                }
+              }
+            },
+            "readable-stream": {
+              "version": "2.3.6",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+              }
+            },
+            "rimraf": {
+              "version": "2.6.3",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "glob": "^7.1.3"
+              }
+            },
+            "safe-buffer": {
+              "version": "5.1.2",
+              "bundled": true,
+              "optional": true
+            },
+            "safer-buffer": {
+              "version": "2.1.2",
+              "bundled": true,
+              "optional": true
+            },
+            "sax": {
+              "version": "1.2.4",
+              "bundled": true,
+              "optional": true
+            },
+            "semver": {
+              "version": "5.7.0",
+              "bundled": true,
+              "optional": true
+            },
+            "set-blocking": {
+              "version": "2.0.0",
+              "bundled": true,
+              "optional": true
+            },
+            "signal-exit": {
+              "version": "3.0.2",
+              "bundled": true,
+              "optional": true
+            },
+            "string-width": {
+              "version": "1.0.2",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
+              }
+            },
+            "string_decoder": {
+              "version": "1.1.1",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "safe-buffer": "~5.1.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "3.0.1",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "ansi-regex": "^2.0.0"
+              }
+            },
+            "strip-json-comments": {
+              "version": "2.0.1",
+              "bundled": true,
+              "optional": true
+            },
+            "tar": {
+              "version": "4.4.8",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "chownr": "^1.1.1",
+                "fs-minipass": "^1.2.5",
+                "minipass": "^2.3.4",
+                "minizlib": "^1.1.1",
+                "mkdirp": "^0.5.0",
+                "safe-buffer": "^5.1.2",
+                "yallist": "^3.0.2"
+              }
+            },
+            "util-deprecate": {
+              "version": "1.0.2",
+              "bundled": true,
+              "optional": true
+            },
+            "wide-align": {
+              "version": "1.1.3",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "string-width": "^1.0.2 || 2"
+              }
+            },
+            "wrappy": {
+              "version": "1.0.2",
+              "bundled": true,
+              "optional": true
+            },
+            "yallist": {
+              "version": "3.0.3",
+              "bundled": true,
+              "optional": true
+            }
+          }
+        },
+        "function-bind": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+          "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+        },
+        "get-stdin": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+          "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4="
+        },
+        "get-value": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+          "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg="
+        },
+        "glob": {
+          "version": "6.0.4",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
+          "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
+          "requires": {
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "glob-base": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
+          "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+          "requires": {
+            "glob-parent": "^2.0.0",
+            "is-glob": "^2.0.0"
+          }
+        },
+        "glob-parent": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+          "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+          "requires": {
+            "is-glob": "^2.0.0"
+          }
+        },
+        "globals": {
+          "version": "11.12.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+          "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="
+        },
+        "globby": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-4.1.0.tgz",
+          "integrity": "sha1-CA9UVJ7BuCpsYOYx/ILhIR2+lfg=",
+          "requires": {
+            "array-union": "^1.0.1",
+            "arrify": "^1.0.0",
+            "glob": "^6.0.1",
+            "object-assign": "^4.0.1",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
+          }
+        },
+        "gossip-query": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/gossip-query/-/gossip-query-2.0.2.tgz",
+          "integrity": "sha512-17MflOq79BYcK01RrqHhtG5Dl88ztSu7gfD+4i1GrpzkbvLDKkJ7LoKiFKzBWzzd+Jd5VhIiLtQRvjRiKa6PUg==",
+          "requires": {
+            "obv": "0.0.1",
+            "pull-stream": "^3.6.0"
+          }
+        },
+        "graceful-fs": {
+          "version": "4.1.15",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
+          "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA=="
+        },
+        "handlebars": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.2.tgz",
+          "integrity": "sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==",
+          "requires": {
+            "neo-async": "^2.6.0",
+            "optimist": "^0.6.1",
+            "source-map": "^0.6.1",
+            "uglify-js": "^3.1.4"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.6.1",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+              "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+            }
+          }
+        },
+        "has": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+          "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+          "requires": {
+            "function-bind": "^1.1.1"
+          }
+        },
+        "has-ansi": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+          "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+        },
+        "has-network": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/has-network/-/has-network-0.0.1.tgz",
+          "integrity": "sha1-Pup7RMqpYBeXEkvouonSKMQQFJk="
+        },
+        "has-symbols": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
+          "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q="
+        },
+        "has-value": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
+          "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
+          "requires": {
+            "get-value": "^2.0.6",
+            "has-values": "^1.0.0",
+            "isobject": "^3.0.0"
+          },
+          "dependencies": {
+            "isobject": {
+              "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+              "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+            }
+          }
+        },
+        "has-values": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
+          "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+          "requires": {
+            "is-number": "^3.0.0",
+            "kind-of": "^4.0.0"
+          },
+          "dependencies": {
+            "is-number": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+              "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+              "requires": {
+                "kind-of": "^3.0.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "3.2.2",
+                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                  "requires": {
+                    "is-buffer": "^1.1.5"
+                  }
+                }
+              }
+            },
+            "kind-of": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+              "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "hashlru": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/hashlru/-/hashlru-2.3.0.tgz",
+          "integrity": "sha512-0cMsjjIC8I+D3M44pOQdsy0OHXGLVz6Z0beRuufhKa0KfaD2wGwAev6jILzXsd3/vpnNQJmWyZtIILqM1N+n5A=="
+        },
+        "he": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/he/-/he-0.5.0.tgz",
+          "integrity": "sha1-LAX/rvkLaOhg8/0rVO9YCYknfuI="
+        },
+        "heap": {
+          "version": "0.2.6",
+          "resolved": "https://registry.npmjs.org/heap/-/heap-0.2.6.tgz",
+          "integrity": "sha1-CH4fELBGky/IWU3Z5tN4r8nR5aw="
+        },
+        "hexpp": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/hexpp/-/hexpp-2.0.0.tgz",
+          "integrity": "sha1-CNZzYlIp4Fl+mB323NRtoaRlXaw="
+        },
+        "hoox": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/hoox/-/hoox-0.0.1.tgz",
+          "integrity": "sha1-CKdNknKpzIOujmu+AwPw7nZDIJQ="
+        },
+        "hosted-git-info": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
+          "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w=="
+        },
+        "idb-kv-store": {
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/idb-kv-store/-/idb-kv-store-4.4.0.tgz",
+          "integrity": "sha1-IsVqjV+QvYj4GKhZ25xYYn3ieL4=",
+          "requires": {
+            "inherits": "^2.0.3",
+            "promisize": "^1.1.2"
+          }
+        },
+        "immediate": {
+          "version": "3.2.3",
+          "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.2.3.tgz",
+          "integrity": "sha1-0UD6j2FGWb1lQSMwl92qwlzdmRw="
+        },
+        "increment-buffer": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/increment-buffer/-/increment-buffer-1.0.1.tgz",
+          "integrity": "sha1-ZQdtdRidgIs5rROrW5WOBSFvng0="
+        },
+        "indent-string": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
+          "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok="
+        },
+        "infer-partial-order": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/infer-partial-order/-/infer-partial-order-0.1.1.tgz",
+          "integrity": "sha1-t3rCJudv1/N6ju3YXY1NbpeRJX4="
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+          "requires": {
+            "once": "^1.3.0",
+            "wrappy": "1"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+        },
+        "ini": {
+          "version": "1.3.5",
+          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+          "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
+        },
+        "int53": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/int53/-/int53-1.0.0.tgz",
+          "integrity": "sha512-u8BMiMa05OPBgd32CKTead0CVTsFVgwFk23nNXo1teKPF6Sxcu0lXxEzP//zTcaKzXbGgPDXGmj/woyv+I4C5w=="
+        },
+        "interleavings": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/interleavings/-/interleavings-1.0.0.tgz",
+          "integrity": "sha512-DAzMdwFFmBZcVvi3cXiEXDY3SMZvSedK6qFICOk0A6ietIUMKyZSgXlyvssakingGkSOLN6SaGnQzqrI6KWIYQ==",
+          "requires": {
+            "debug": "^4.1.1",
+            "infer-partial-order": "~0.1.1",
+            "rng": "~0.2.2"
+          }
+        },
         "ip": {
           "version": "1.1.5",
           "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
           "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
-        }
-      }
-    },
-    "ssb-sort": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/ssb-sort/-/ssb-sort-0.0.0.tgz",
-      "integrity": "sha1-OEwus/pIzEbF8R1Za/aGYZ+ol58=",
-      "requires": {
-        "ssb-ref": "2.9.1"
-      }
-    },
-    "ssb-validate": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ssb-validate/-/ssb-validate-3.0.0.tgz",
-      "integrity": "sha1-jDsLdhGabaQ4TMB78NMiYxAUuUU=",
-      "requires": {
-        "ssb-ref": "2.9.1"
-      }
-    },
-    "ssb-ws": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/ssb-ws/-/ssb-ws-1.0.3.tgz",
-      "integrity": "sha1-+68EZOCWaPS7lRbSxBzcA6nWgdw=",
-      "requires": {
-        "emoji-server": "1.0.0",
-        "multiblob-http": "0.2.1",
-        "multiserver": "1.10.1",
-        "muxrpc": "6.4.0",
-        "pull-stream": "3.6.1",
-        "ssb-ref": "2.9.1",
-        "ssb-sort": "0.0.0",
-        "stack": "0.1.0",
-        "web-bootloader": "0.1.2"
-      }
-    },
-    "stack": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/stack/-/stack-0.1.0.tgz",
-      "integrity": "sha1-6SNZipvlHmF2gsshzxsoGKRJraI="
-    },
-    "statistics": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/statistics/-/statistics-3.3.0.tgz",
-      "integrity": "sha1-7HtHUP8DqySmTdmzV6eDFr6teKo="
-    },
-    "stream-to-pull-stream": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/stream-to-pull-stream/-/stream-to-pull-stream-1.7.2.tgz",
-      "integrity": "sha1-dXYJrhzr0zx0MtSvvjH/eGULnd4=",
-      "requires": {
-        "looper": "3.0.0",
-        "pull-stream": "3.6.1"
-      },
-      "dependencies": {
+        },
+        "irregular-plurals": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-1.4.0.tgz",
+          "integrity": "sha1-LKmwM2UREYVUEvFr5dd8YqRYp2Y="
+        },
+        "is-accessor-descriptor": {
+          "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+          "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+          "requires": {
+            "kind-of": "^3.0.2"
+          }
+        },
+        "is-alphabetical": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.3.tgz",
+          "integrity": "sha512-eEMa6MKpHFzw38eKm56iNNi6GJ7lf6aLLio7Kr23sJPAECscgRtZvOBYybejWDQ2bM949Y++61PY+udzj5QMLA=="
+        },
+        "is-alphanumerical": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.3.tgz",
+          "integrity": "sha512-A1IGAPO5AW9vSh7omxIlOGwIqEvpW/TA+DksVOPM5ODuxKlZS09+TEM1E3275lJqO2oJ38vDpeAL3DCIiHE6eA==",
+          "requires": {
+            "is-alphabetical": "^1.0.0",
+            "is-decimal": "^1.0.0"
+          }
+        },
+        "is-arrayish": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+          "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
+        },
+        "is-binary-path": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
+          "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
+          "requires": {
+            "binary-extensions": "^1.0.0"
+          }
+        },
+        "is-buffer": {
+          "version": "1.1.6",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+          "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+        },
+        "is-callable": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
+          "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA=="
+        },
+        "is-canonical-base64": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/is-canonical-base64/-/is-canonical-base64-1.1.1.tgz",
+          "integrity": "sha512-o6t/DwgEapC0bsloqtegAQyZzQXaQ5+8fzsyf2KmLqupC2ifLFq/lMQiFCJeGpdSrK1o6GL+WW2lRU050lLlFg=="
+        },
+        "is-data-descriptor": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+          "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+          "requires": {
+            "kind-of": "^3.0.2"
+          }
+        },
+        "is-date-object": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+          "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
+        },
+        "is-decimal": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.3.tgz",
+          "integrity": "sha512-bvLSwoDg2q6Gf+E2LEPiklHZxxiSi3XAh4Mav65mKqTfCO1HM3uBs24TjEH8iJX3bbDdLXKJXBTmGzuTUuAEjQ=="
+        },
+        "is-descriptor": {
+          "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+          "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+          "requires": {
+            "is-accessor-descriptor": "^0.1.6",
+            "is-data-descriptor": "^0.1.4",
+            "kind-of": "^5.0.0"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "5.1.0",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+              "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
+            }
+          }
+        },
+        "is-dotfile": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
+          "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE="
+        },
+        "is-electron": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/is-electron/-/is-electron-2.2.0.tgz",
+          "integrity": "sha512-SpMppC2XR3YdxSzczXReBjqs2zGscWQpBIKqwXYBFic0ERaxNVgwLCHwOLZeESfdJQjX0RDvrJ1lBXX2ij+G1Q=="
+        },
+        "is-equal-shallow": {
+          "version": "0.1.3",
+          "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+          "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+          "requires": {
+            "is-primitive": "^2.0.0"
+          }
+        },
+        "is-extendable": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+          "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
+        },
+        "is-extglob": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+        },
+        "is-finite": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+          "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "is-glob": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+          "requires": {
+            "is-extglob": "^1.0.0"
+          }
+        },
+        "is-hexadecimal": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.3.tgz",
+          "integrity": "sha512-zxQ9//Q3D/34poZf8fiy3m3XVpbQc7ren15iKqrTtLPwkPD/t3Scy9Imp63FujULGxuK0ZlCwoo5xNpktFgbOA=="
+        },
+        "is-number": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+          "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+          "requires": {
+            "kind-of": "^3.0.2"
+          }
+        },
+        "is-plain-obj": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+          "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
+        },
+        "is-plain-object": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+          "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+          "requires": {
+            "isobject": "^3.0.1"
+          },
+          "dependencies": {
+            "isobject": {
+              "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+              "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+            }
+          }
+        },
+        "is-posix-bracket": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
+          "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q="
+        },
+        "is-primitive": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+          "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
+        },
+        "is-regex": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
+          "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+          "requires": {
+            "has": "^1.0.1"
+          }
+        },
+        "is-symbol": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
+          "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
+          "requires": {
+            "has-symbols": "^1.0.0"
+          }
+        },
+        "is-typedarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+          "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+        },
+        "is-utf8": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+          "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
+        },
+        "is-valid-domain": {
+          "version": "0.0.9",
+          "resolved": "https://registry.npmjs.org/is-valid-domain/-/is-valid-domain-0.0.9.tgz",
+          "integrity": "sha512-IeK/VigfxtjHCrNTY2/Lwed7Gp1VWPRSqtJ4GcaDUJ20AxmsL9Saoz96Q/yvf+y5N8zCjJb9HrA3vUlL8tk5Zg=="
+        },
+        "is-windows": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+          "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+        },
+        "isexe": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+          "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+        },
+        "isobject": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+          "requires": {
+            "isarray": "1.0.0"
+          }
+        },
+        "istanbul-lib-coverage": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.5.tgz",
+          "integrity": "sha512-8aXznuEPCJvGnMSRft4udDRDtb1V3pkQkMMI5LI+6HuQz5oQ4J2UFn1H82raA3qJtyOLkkwVqICBQkjnGtn5mA=="
+        },
+        "istanbul-lib-instrument": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-3.3.0.tgz",
+          "integrity": "sha512-5nnIN4vo5xQZHdXno/YDXJ0G+I3dAm4XgzfSVTPLQpj/zAV2dV6Juy0yaf10/zrJOJeHoN3fraFe+XRq2bFVZA==",
+          "requires": {
+            "@babel/generator": "^7.4.0",
+            "@babel/parser": "^7.4.3",
+            "@babel/template": "^7.4.0",
+            "@babel/traverse": "^7.4.3",
+            "@babel/types": "^7.4.0",
+            "istanbul-lib-coverage": "^2.0.5",
+            "semver": "^6.0.0"
+          },
+          "dependencies": {
+            "semver": {
+              "version": "6.0.0",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-6.0.0.tgz",
+              "integrity": "sha512-0UewU+9rFapKFnlbirLi3byoOuhrSsli/z/ihNnvM24vgF+8sNBiI1LZPBSH9wJKUwaUbw+s3hToDLCXkrghrQ=="
+            }
+          }
+        },
+        "js-tokens": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+          "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+        },
+        "jsesc": {
+          "version": "2.5.2",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+          "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA=="
+        },
+        "json-buffer": {
+          "version": "2.0.11",
+          "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-2.0.11.tgz",
+          "integrity": "sha1-PkQf2jCYvo0eMXGtWRvGKjPi1V8="
+        },
+        "json-parse-better-errors": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+          "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw=="
+        },
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        },
+        "layered-graph": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/layered-graph/-/layered-graph-1.1.3.tgz",
+          "integrity": "sha512-0lACDagchA0cEiOxP90bLJm8Asxw5p089BozVvPAcKYPigQBxA1Ca4foEPBuz4x8RRZYybiksc/qBR1YurSUHA==",
+          "requires": {
+            "dynamic-dijkstra": "^1.0.0",
+            "pull-cont": "^0.1.1",
+            "pull-notify": "^0.1.1",
+            "pull-stream": "^3.6.9"
+          }
+        },
+        "level": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/level/-/level-5.0.1.tgz",
+          "integrity": "sha512-wcak5OQeA4rURGacqS62R/xNHjCYnJSQDBOlm4KNUGJVE9bWv2B04TclqReYejN+oD65PzD4FsqeWoI5wNC5Lg==",
+          "requires": {
+            "level-js": "^4.0.0",
+            "level-packager": "^5.0.0",
+            "leveldown": "^5.0.0",
+            "opencollective-postinstall": "^2.0.0"
+          }
+        },
+        "level-codec": {
+          "version": "9.0.1",
+          "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-9.0.1.tgz",
+          "integrity": "sha512-ajFP0kJ+nyq4i6kptSM+mAvJKLOg1X5FiFPtLG9M5gCEZyBmgDi3FkDrvlMkEzrUn1cWxtvVmrvoS4ASyO/q+Q=="
+        },
+        "level-concat-iterator": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/level-concat-iterator/-/level-concat-iterator-2.0.1.tgz",
+          "integrity": "sha512-OTKKOqeav2QWcERMJR7IS9CUo1sHnke2C0gkSmcR7QuEtFNLLzHQAvnMw8ykvEcv0Qtkg0p7FOwP1v9e5Smdcw=="
+        },
+        "level-errors": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-2.0.1.tgz",
+          "integrity": "sha512-UVprBJXite4gPS+3VznfgDSU8PTRuVX0NXwoWW50KLxd2yw4Y1t2JUR5In1itQnudZqRMT9DlAM3Q//9NCjCFw==",
+          "requires": {
+            "errno": "~0.1.1"
+          }
+        },
+        "level-iterator-stream": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-4.0.1.tgz",
+          "integrity": "sha512-pSZWqXK6/yHQkZKCHrR59nKpU5iqorKM22C/BOHTb/cwNQ2EOZG+bovmFFGcOgaBoF3KxqJEI27YwewhJQTzsw==",
+          "requires": {
+            "inherits": "^2.0.1",
+            "readable-stream": "^3.0.2",
+            "xtend": "^4.0.0"
+          },
+          "dependencies": {
+            "readable-stream": {
+              "version": "3.3.0",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.3.0.tgz",
+              "integrity": "sha512-EsI+s3k3XsW+fU8fQACLN59ky34AZ14LoeVZpYwmZvldCFo0r0gnelwF2TcMjLor/BTL5aDJVBMkss0dthToPw==",
+              "requires": {
+                "inherits": "^2.0.3",
+                "string_decoder": "^1.1.1",
+                "util-deprecate": "^1.0.1"
+              }
+            }
+          }
+        },
+        "level-js": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/level-js/-/level-js-4.0.1.tgz",
+          "integrity": "sha512-m5JRIyHZn5VnCCFeRegJkn5bQd3MJK5qZX12zg3Oivc8+BUIS2yFS6ANMMeHX2ieGxucNvEn6/ZnyjmZQLLUWw==",
+          "requires": {
+            "abstract-leveldown": "~6.0.1",
+            "immediate": "~3.2.3",
+            "inherits": "^2.0.3",
+            "ltgt": "^2.1.2",
+            "typedarray-to-buffer": "~3.1.5"
+          }
+        },
+        "level-packager": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/level-packager/-/level-packager-5.0.1.tgz",
+          "integrity": "sha512-tigB8g7xnFE5es2d/OmGJvcJC9S+FQfJnnULSLbPr53/ABPIaCarCxofkwdBhnJxjLZCNvj/Je6luFj/XeuaUQ==",
+          "requires": {
+            "encoding-down": "^6.0.0",
+            "levelup": "^4.0.0"
+          }
+        },
+        "level-post": {
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/level-post/-/level-post-1.0.7.tgz",
+          "integrity": "sha512-PWYqG4Q00asOrLhX7BejSajByB4EmG2GaKHfj3h5UmmZ2duciXLPGYWIjBzLECFWUGOZWlm5B20h/n3Gs3HKew==",
+          "requires": {
+            "ltgt": "^2.1.2"
+          }
+        },
+        "level-sublevel": {
+          "version": "6.6.5",
+          "resolved": "https://registry.npmjs.org/level-sublevel/-/level-sublevel-6.6.5.tgz",
+          "integrity": "sha512-SBSR60x+dghhwGUxPKS+BvV1xNqnwsEUBKmnFepPaHJ6VkBXyPK9SImGc3K2BkwBfpxlt7GKkBNlCnrdufsejA==",
+          "requires": {
+            "bytewise": "~1.1.0",
+            "levelup": "~0.19.0",
+            "ltgt": "~2.1.1",
+            "pull-defer": "^0.2.2",
+            "pull-level": "^2.0.3",
+            "pull-stream": "^3.6.8",
+            "typewiselite": "~1.0.0",
+            "xtend": "~4.0.0"
+          },
+          "dependencies": {
+            "abstract-leveldown": {
+              "version": "0.12.4",
+              "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-0.12.4.tgz",
+              "integrity": "sha1-KeGOYy5g5OIh1YECR4UqY9ey5BA=",
+              "requires": {
+                "xtend": "~3.0.0"
+              },
+              "dependencies": {
+                "xtend": {
+                  "version": "3.0.0",
+                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
+                  "integrity": "sha1-XM50B7r2Qsunvs2laBEcST9ZZlo="
+                }
+              }
+            },
+            "deferred-leveldown": {
+              "version": "0.2.0",
+              "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-0.2.0.tgz",
+              "integrity": "sha1-LO8fER4cV4cNi7uK8mUOWHzS9bQ=",
+              "requires": {
+                "abstract-leveldown": "~0.12.1"
+              }
+            },
+            "isarray": {
+              "version": "0.0.1",
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+              "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+            },
+            "levelup": {
+              "version": "0.19.1",
+              "resolved": "https://registry.npmjs.org/levelup/-/levelup-0.19.1.tgz",
+              "integrity": "sha1-86anIFJyxLXzXkEv8ASgOgrt9Qs=",
+              "requires": {
+                "bl": "~0.8.1",
+                "deferred-leveldown": "~0.2.0",
+                "errno": "~0.1.1",
+                "prr": "~0.0.0",
+                "readable-stream": "~1.0.26",
+                "semver": "~5.1.0",
+                "xtend": "~3.0.0"
+              },
+              "dependencies": {
+                "xtend": {
+                  "version": "3.0.0",
+                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
+                  "integrity": "sha1-XM50B7r2Qsunvs2laBEcST9ZZlo="
+                }
+              }
+            },
+            "ltgt": {
+              "version": "2.1.3",
+              "resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.1.3.tgz",
+              "integrity": "sha1-EIUaBtmWS5cReEQcI8nlJpjuzjQ="
+            },
+            "prr": {
+              "version": "0.0.0",
+              "resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz",
+              "integrity": "sha1-GoS4WQgyVQFBGFPQCB7j+obikmo="
+            },
+            "readable-stream": {
+              "version": "1.0.34",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+              "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.1",
+                "isarray": "0.0.1",
+                "string_decoder": "~0.10.x"
+              }
+            },
+            "semver": {
+              "version": "5.1.1",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.1.tgz",
+              "integrity": "sha1-oykqNz5vPgeY2gsgZBuanFvEfhk="
+            },
+            "string_decoder": {
+              "version": "0.10.31",
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+              "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+            }
+          }
+        },
+        "leveldown": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/leveldown/-/leveldown-5.1.0.tgz",
+          "integrity": "sha512-+Ws1IDVSbJRJl/cP/JlapGSmt8xPSvZQpTlYGpyaMQiXtlx/fdMX30K2aHiTLxhLcnAg74D8odBG1Fk12/8SRA==",
+          "requires": {
+            "abstract-leveldown": "~6.0.3",
+            "fast-future": "~1.0.2",
+            "napi-macros": "~1.8.1",
+            "node-gyp-build": "~4.1.0"
+          },
+          "dependencies": {
+            "node-gyp-build": {
+              "version": "4.1.0",
+              "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.1.0.tgz",
+              "integrity": "sha512-rGLv++nK20BG8gc0MzzcYe1Nl3p3mtwJ74Q2QD0HTEDKZ6NvOFSelY6s2QBPWIHRR8h7hpad0LiwajfClBJfNg=="
+            }
+          }
+        },
+        "levelup": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/levelup/-/levelup-4.0.1.tgz",
+          "integrity": "sha512-l7KXOkINXHgNqmz0v9bxvRnMCUG4gmShFrzFSZXXhcqFnfvKAW8NerVsTICpZtVhGOMAmhY6JsVoVh/tUPBmdg==",
+          "requires": {
+            "deferred-leveldown": "~5.0.0",
+            "level-errors": "~2.0.0",
+            "level-iterator-stream": "~4.0.0",
+            "xtend": "~4.0.0"
+          }
+        },
+        "libnested": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/libnested/-/libnested-1.4.1.tgz",
+          "integrity": "sha512-7fvNHrU8QTep71gIJuz7z6iBAQULEHJOcIA0MKUlwFrSnntvOvnke+/tnR7ZxyRAQQ303UJXNZBSRz3r0N5tqw=="
+        },
+        "libsodium": {
+          "version": "0.7.4",
+          "resolved": "https://registry.npmjs.org/libsodium/-/libsodium-0.7.4.tgz",
+          "integrity": "sha512-fTU3vUdrxQzhPAAjmTSqKk4LzYbR0OtcYjp1P92AlH50JIxXZFEIXWh1yryCmU6RLGfwS2IzBdZjbmpYf/TlyQ=="
+        },
+        "libsodium-wrappers": {
+          "version": "0.7.4",
+          "resolved": "https://registry.npmjs.org/libsodium-wrappers/-/libsodium-wrappers-0.7.4.tgz",
+          "integrity": "sha512-axKkW01L0q+urLeE7UMSZKWwk4LrRbi6s5pjKBAvbgDBYnsSaolK1oN/Syilm1dqJFkJQNi6qodwOp8dzSoc9Q==",
+          "requires": {
+            "libsodium": "0.7.4"
+          }
+        },
+        "load-json-file": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+          "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^4.0.0",
+            "pify": "^3.0.0",
+            "strip-bom": "^3.0.0"
+          },
+          "dependencies": {
+            "pify": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+              "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+            }
+          }
+        },
+        "locate-path": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+          "requires": {
+            "p-locate": "^2.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+        },
+        "lodash.get": {
+          "version": "4.4.2",
+          "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+          "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
+        },
+        "log-symbols": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
+          "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
+          "requires": {
+            "chalk": "^1.0.0"
+          }
+        },
+        "log-update": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/log-update/-/log-update-1.0.2.tgz",
+          "integrity": "sha1-GZKfZMQJPS0ucHWh2tivWcKWuNE=",
+          "requires": {
+            "ansi-escapes": "^1.0.0",
+            "cli-cursor": "^1.0.2"
+          }
+        },
+        "longest-streak": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-1.0.0.tgz",
+          "integrity": "sha1-0GWXxNTDG1LMsfXY+P5xSOr9aWU="
+        },
         "looper": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/looper/-/looper-4.0.0.tgz",
+          "integrity": "sha1-dwat7VmpntygbmtUu4bI7BnJUVU="
+        },
+        "lossy-store": {
+          "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/lossy-store/-/lossy-store-1.2.4.tgz",
+          "integrity": "sha512-rvqTCHZxWLvHAJv2w5vdCr5xICAW/FiXQ9wZGaAfBlNGG2FuLX0URNcj/zXC3qr5zQ8lBCbW8EEmDCKi7Dsp1g==",
+          "requires": {
+            "mkdirp": "^0.5.1",
+            "tape": "^4.6.3"
+          }
+        },
+        "loud-rejection": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
+          "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
+          "requires": {
+            "currently-unhandled": "^0.4.1",
+            "signal-exit": "^3.0.0"
+          }
+        },
+        "ltgt": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.2.1.tgz",
+          "integrity": "sha1-81ypHEk/e3PaDgdJUwTxezH4fuU="
+        },
+        "map-cache": {
+          "version": "0.2.2",
+          "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
+          "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8="
+        },
+        "map-filter-reduce": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/map-filter-reduce/-/map-filter-reduce-2.2.1.tgz",
+          "integrity": "sha1-YysSfDrl1q2eIc/dlpG2O4lE/NI=",
+          "requires": {
+            "binary-search": "^1.2.0",
+            "pull-sink-through": "0.0.0",
+            "pull-stream": "^3.3.0",
+            "typewiselite": "^1.0.0"
+          }
+        },
+        "map-merge": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/map-merge/-/map-merge-1.1.0.tgz",
+          "integrity": "sha1-am/FjJXYqrRsK93kTVFbbuBvzjQ="
+        },
+        "map-obj": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz",
+          "integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk="
+        },
+        "map-visit": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
+          "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+          "requires": {
+            "object-visit": "^1.0.0"
+          }
+        },
+        "markdown-table": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-0.4.0.tgz",
+          "integrity": "sha1-iQwsGzv+g/sA5BKbjkz+ZFJw+dE="
+        },
+        "math-random": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.4.tgz",
+          "integrity": "sha512-rUxjysqif/BZQH2yhd5Aaq7vXMSx9NdEsQcyA07uEzIvxgI7zIr33gGsh+RU0/XjmQpCW7RsVof1vlkvQVCK5A=="
+        },
+        "mdmanifest": {
+          "version": "1.0.8",
+          "resolved": "https://registry.npmjs.org/mdmanifest/-/mdmanifest-1.0.8.tgz",
+          "integrity": "sha1-wEiRiDwoyDYC4dBrBaEQN+NZtMg=",
+          "requires": {
+            "minimist": "^1.2.0",
+            "remark": "^3.2.2",
+            "remark-html": "^2.0.2",
+            "word-wrap": "^1.1.0"
+          }
+        },
+        "meow": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/meow/-/meow-5.0.0.tgz",
+          "integrity": "sha512-CbTqYU17ABaLefO8vCU153ZZlprKYWDljcndKKDCFcYQITzWCXZAVk4QMFZPgvzrnUQ3uItnIE/LoUOwrT15Ig==",
+          "requires": {
+            "camelcase-keys": "^4.0.0",
+            "decamelize-keys": "^1.0.0",
+            "loud-rejection": "^1.0.0",
+            "minimist-options": "^3.0.1",
+            "normalize-package-data": "^2.3.4",
+            "read-pkg-up": "^3.0.0",
+            "redent": "^2.0.0",
+            "trim-newlines": "^2.0.0",
+            "yargs-parser": "^10.0.0"
+          }
+        },
+        "micromatch": {
+          "version": "2.3.11",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+          "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+          "requires": {
+            "arr-diff": "^2.0.0",
+            "array-unique": "^0.2.1",
+            "braces": "^1.8.2",
+            "expand-brackets": "^0.1.4",
+            "extglob": "^0.3.1",
+            "filename-regex": "^2.0.0",
+            "is-extglob": "^1.0.0",
+            "is-glob": "^2.0.1",
+            "kind-of": "^3.0.2",
+            "normalize-path": "^2.0.1",
+            "object.omit": "^2.0.0",
+            "parse-glob": "^3.0.4",
+            "regex-cache": "^0.4.2"
+          }
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+        },
+        "minimist-options": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-3.0.2.tgz",
+          "integrity": "sha512-FyBrT/d0d4+uiZRbqznPXqw3IpZZG3gl3wKWiX784FycUKVwBt0uLBFkQrtE4tZOrgo78nZp2jnKz3L65T5LdQ==",
+          "requires": {
+            "arrify": "^1.0.1",
+            "is-plain-obj": "^1.1.0"
+          }
+        },
+        "mixin-deep": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
+          "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
+          "requires": {
+            "for-in": "^1.0.2",
+            "is-extendable": "^1.0.1"
+          },
+          "dependencies": {
+            "is-extendable": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+              "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+              "requires": {
+                "is-plain-object": "^2.0.4"
+              }
+            }
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "requires": {
+            "minimist": "0.0.8"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.8",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+            }
+          }
+        },
+        "monotonic-timestamp": {
+          "version": "0.0.9",
+          "resolved": "https://registry.npmjs.org/monotonic-timestamp/-/monotonic-timestamp-0.0.9.tgz",
+          "integrity": "sha1-W6Wtx6rIXh1853voRxYe0kazlgM="
+        },
+        "moo": {
+          "version": "0.4.3",
+          "resolved": "https://registry.npmjs.org/moo/-/moo-0.4.3.tgz",
+          "integrity": "sha512-gFD2xGCl8YFgGHsqJ9NKRVdwlioeW3mI1iqfLNYQOv0+6JRwG58Zk9DIGQgyIaffSYaO1xsKnMaYzzNr1KyIAw=="
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+        },
+        "multiblob": {
+          "version": "1.13.4",
+          "resolved": "https://registry.npmjs.org/multiblob/-/multiblob-1.13.4.tgz",
+          "integrity": "sha512-2uv89W7I5brTx6ETpE7kXv0dGC3iA+xrAxNtwjwb3lwBTXIYrJ4jhhVX5UyNaRWHdmfLe0dJeEvJm9uoekkmag==",
+          "requires": {
+            "blake2s": "^1.0.1",
+            "cont": "^1.0.1",
+            "explain-error": "^1.0.1",
+            "mkdirp": "^0.5.0",
+            "pull-catch": "^1.0.0",
+            "pull-defer": "^0.2.2",
+            "pull-file": "^1.0.0",
+            "pull-glob": "~1.0.6",
+            "pull-live": "^1.0.0",
+            "pull-notify": "^0.1.1",
+            "pull-paramap": "^1.2.2",
+            "pull-stream": "^3.6.2",
+            "pull-write-file": "^0.2.1",
+            "rimraf": "^2.2.8",
+            "stream-to-pull-stream": "^1.7.2"
+          }
+        },
+        "multiblob-http": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/multiblob-http/-/multiblob-http-1.0.0.tgz",
+          "integrity": "sha512-wKsVFCi3lSR75peYpFMRDbWeGm86qgYfBe9Otm8j73rs+a1OltSLcg8fsTCO+pJTbYyIV92Iw5lnVYYTs7zMvg==",
+          "requires": {
+            "pull-many": "^1.0.8",
+            "pull-stream": "^3.4.3",
+            "range-parser": "^1.2.0",
+            "stream-to-pull-stream": "^1.7.0"
+          }
+        },
+        "multicb": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/multicb/-/multicb-1.2.2.tgz",
+          "integrity": "sha512-PZM4dhYFmCF6uZGWpEmoPMUqJBywS9IcAgybT2GmSpYI1BvGvoWSdbio+ik+q/YD2vodhvslESWIS3NnkKYdqQ=="
+        },
+        "multiserver": {
+          "version": "3.3.6",
+          "resolved": "https://registry.npmjs.org/multiserver/-/multiserver-3.3.6.tgz",
+          "integrity": "sha512-zuPjEaPEVMosWXnfNalXv3QyjYCwaD2emC6l/ozwMeaCcZ/Do7WMb/ZF8MC6TVwhV9Y7eTcnBiYEP/hq8zA2nA==",
+          "requires": {
+            "debug": "^4.1.1",
+            "multicb": "^1.2.2",
+            "multiserver-scopes": "^1.0.0",
+            "pull-cat": "~1.1.5",
+            "pull-stream": "^3.6.1",
+            "pull-ws": "^3.3.0",
+            "secret-handshake": "^1.1.16",
+            "separator-escape": "0.0.0",
+            "socks": "^2.2.3",
+            "stream-to-pull-stream": "^1.7.2"
+          }
+        },
+        "multiserver-address": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/multiserver-address/-/multiserver-address-1.0.1.tgz",
+          "integrity": "sha512-IfZMAGs9onCLkYNSnNBri3JxuvhQYllMyh3W9ry86iEDcfW9uPVsHTHDsjDxQtL+dPq3byshmA+Y4LN2wLHwNw==",
+          "requires": {
+            "nearley": "^2.15.1"
+          }
+        },
+        "multiserver-scopes": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/multiserver-scopes/-/multiserver-scopes-1.0.0.tgz",
+          "integrity": "sha512-D3q4IujGRUIKETfR5s0kRtvXTjAMhyl7rtLEMXtvkg0lJPJyS5KYsAULFFy+dYv/+RC642aR1zo/RKNp6sdtQg==",
+          "requires": {
+            "non-private-ip": "^1.4.4"
+          }
+        },
+        "muxrpc": {
+          "version": "6.4.2",
+          "resolved": "https://registry.npmjs.org/muxrpc/-/muxrpc-6.4.2.tgz",
+          "integrity": "sha512-1wRnouHgHO3JYN3xbyzQGTFsd/wo12/zaikmQusP8ma+lmL+ewNvuvuwKSEJasKQTRnbTwbzh/OPdt9N76CA4g==",
+          "requires": {
+            "explain-error": "^1.0.1",
+            "packet-stream": "~2.0.0",
+            "packet-stream-codec": "^1.1.1",
+            "pull-goodbye": "0.0.2",
+            "pull-stream": "^3.2.3"
+          }
+        },
+        "muxrpc-usage": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/muxrpc-usage/-/muxrpc-usage-2.1.0.tgz",
+          "integrity": "sha512-ZspYQd4n4pLy86Gu/yrEdHvg5NBrg4p2NayQ2NFelN1QyLZRLTKPlTyaa6DyztsCG7mjLzxFBw9jw9LReB8Azw==",
+          "requires": {
+            "right-pad": "^1.0.1"
+          }
+        },
+        "muxrpc-validation": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/looper/-/looper-3.0.0.tgz",
-          "integrity": "sha1-LvpUw7HLq6m5Su4uWRSwvlf7t0k="
+          "resolved": "https://registry.npmjs.org/muxrpc-validation/-/muxrpc-validation-3.0.0.tgz",
+          "integrity": "sha1-47bAMaetOA8CrWfZMG1PGz+NNdY=",
+          "requires": {
+            "pull-stream": "^2.28.3",
+            "zerr": "^1.0.1"
+          },
+          "dependencies": {
+            "pull-stream": {
+              "version": "2.28.4",
+              "resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-2.28.4.tgz",
+              "integrity": "sha1-fql0E8FhnCC8O9+eEOkTR7AyU+Q=",
+              "requires": {
+                "pull-core": "~1.1.0"
+              }
+            }
+          }
+        },
+        "muxrpcli": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/muxrpcli/-/muxrpcli-3.1.0.tgz",
+          "integrity": "sha512-GvnPFBTA5oHHJDI9U7cwiOWCbVOLHcuO8cprwRLPD/zEXBQWeZ5qOw3/wpT2GGFyXL/gCDm456EjYj7hjY7jiA==",
+          "requires": {
+            "cont": "^1.0.3",
+            "minimist": "^1.2.0",
+            "muxrpc-usage": "^2.0.1",
+            "pull-stream": "^3.6.9",
+            "stream-to-pull-stream": "^1.7.3",
+            "word-wrap": "^1.2.3"
+          }
+        },
+        "mv": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/mv/-/mv-2.1.1.tgz",
+          "integrity": "sha1-rmzg1vbV4KT32JN5jQPB6pVZtqI=",
+          "requires": {
+            "mkdirp": "~0.5.1",
+            "ncp": "~2.0.0",
+            "rimraf": "~2.4.0"
+          },
+          "dependencies": {
+            "rimraf": {
+              "version": "2.4.5",
+              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.5.tgz",
+              "integrity": "sha1-7nEM5dk6j9uFb7Xqj/Di11k0sto=",
+              "requires": {
+                "glob": "^6.0.1"
+              }
+            }
+          }
+        },
+        "nan": {
+          "version": "2.14.0",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+          "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
+          "optional": true
+        },
+        "nanomatch": {
+          "version": "1.2.13",
+          "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
+          "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
+          "requires": {
+            "arr-diff": "^4.0.0",
+            "array-unique": "^0.3.2",
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "fragment-cache": "^0.2.1",
+            "is-windows": "^1.0.2",
+            "kind-of": "^6.0.2",
+            "object.pick": "^1.3.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "arr-diff": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+              "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
+            },
+            "array-unique": {
+              "version": "0.3.2",
+              "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+              "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
+            },
+            "kind-of": {
+              "version": "6.0.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+              "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+            }
+          }
+        },
+        "napi-macros": {
+          "version": "1.8.2",
+          "resolved": "https://registry.npmjs.org/napi-macros/-/napi-macros-1.8.2.tgz",
+          "integrity": "sha512-Tr0DNY4RzTaBG2W2m3l7ZtFuJChTH6VZhXVhkGGjF/4cZTt+i8GcM9ozD+30Lmr4mDoZ5Xx34t2o4GJqYWDGcg=="
+        },
+        "ncp": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
+          "integrity": "sha1-GVoh1sRuNh0vsSgbo4uR6d9727M="
+        },
+        "nearley": {
+          "version": "2.16.0",
+          "resolved": "https://registry.npmjs.org/nearley/-/nearley-2.16.0.tgz",
+          "integrity": "sha512-Tr9XD3Vt/EujXbZBv6UAHYoLUSMQAxSsTnm9K3koXzjzNWY195NqALeyrzLZBKzAkL3gl92BcSogqrHjD8QuUg==",
+          "requires": {
+            "commander": "^2.19.0",
+            "moo": "^0.4.3",
+            "railroad-diagrams": "^1.0.0",
+            "randexp": "0.4.6",
+            "semver": "^5.4.1"
+          }
+        },
+        "neo-async": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
+          "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw=="
+        },
+        "nice-try": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+          "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
+        },
+        "node-gyp-build": {
+          "version": "3.9.0",
+          "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-3.9.0.tgz",
+          "integrity": "sha512-zLcTg6P4AbcHPq465ZMFNXx7XpKKJh+7kkN699NiQWisR2uWYOWNWqRHAmbnmKiL4e9aLSlmy5U7rEMUXV59+A==",
+          "optional": true
+        },
+        "non-private-ip": {
+          "version": "1.4.4",
+          "resolved": "https://registry.npmjs.org/non-private-ip/-/non-private-ip-1.4.4.tgz",
+          "integrity": "sha512-K9nTVFOGUOYutaG8ywiKpCdVu458RFxSgSJ0rribUxtf5iLM9B2+raFJgkID3p5op0+twmoQqFaPnu9KYz6qzg==",
+          "requires": {
+            "ip": "^1.1.5"
+          }
+        },
+        "normalize-package-data": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+          "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+          "requires": {
+            "hosted-git-info": "^2.1.4",
+            "resolve": "^1.10.0",
+            "semver": "2 || 3 || 4 || 5",
+            "validate-npm-package-license": "^3.0.1"
+          }
+        },
+        "normalize-path": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+          "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+          "requires": {
+            "remove-trailing-separator": "^1.0.1"
+          }
+        },
+        "normalize-uri": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/normalize-uri/-/normalize-uri-1.1.2.tgz",
+          "integrity": "sha512-fHgUX0J9LLSfIQAX1jfn+E47Sh24eKm41flnEjLeMKL9VoW3z/QkOrlJqKbcnO5qWcKSH57o5nH+3V0NOXmvDw=="
+        },
+        "npm-install-package": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/npm-install-package/-/npm-install-package-2.1.0.tgz",
+          "integrity": "sha1-1+/jz816sAYUuJbqUxGdyaslkSU="
+        },
+        "npm-prefix": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/npm-prefix/-/npm-prefix-1.2.0.tgz",
+          "integrity": "sha1-5hlFX3B0ulTMZtbQ033Z8b5ry8A=",
+          "requires": {
+            "rc": "^1.1.0",
+            "shellsubstitute": "^1.1.0",
+            "untildify": "^2.1.0"
+          }
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+        },
+        "nyc": {
+          "version": "13.3.0",
+          "resolved": "https://registry.npmjs.org/nyc/-/nyc-13.3.0.tgz",
+          "integrity": "sha512-P+FwIuro2aFG6B0Esd9ZDWUd51uZrAEoGutqZxzrVmYl3qSfkLgcQpBPBjtDFsUQLFY1dvTQJPOyeqr8S9GF8w==",
+          "requires": {
+            "archy": "^1.0.0",
+            "arrify": "^1.0.1",
+            "caching-transform": "^3.0.1",
+            "convert-source-map": "^1.6.0",
+            "find-cache-dir": "^2.0.0",
+            "find-up": "^3.0.0",
+            "foreground-child": "^1.5.6",
+            "glob": "^7.1.3",
+            "istanbul-lib-coverage": "^2.0.3",
+            "istanbul-lib-hook": "^2.0.3",
+            "istanbul-lib-instrument": "^3.1.0",
+            "istanbul-lib-report": "^2.0.4",
+            "istanbul-lib-source-maps": "^3.0.2",
+            "istanbul-reports": "^2.1.1",
+            "make-dir": "^1.3.0",
+            "merge-source-map": "^1.1.0",
+            "resolve-from": "^4.0.0",
+            "rimraf": "^2.6.3",
+            "signal-exit": "^3.0.2",
+            "spawn-wrap": "^1.4.2",
+            "test-exclude": "^5.1.0",
+            "uuid": "^3.3.2",
+            "yargs": "^12.0.5",
+            "yargs-parser": "^11.1.1"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+              "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+            },
+            "append-transform": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/append-transform/-/append-transform-1.0.0.tgz",
+              "integrity": "sha512-P009oYkeHyU742iSZJzZZywj4QRJdnTWffaKuJQLablCZ1uz6/cW4yaRgcDaoQ+uwOxxnt0gRUcwfsNP2ri0gw==",
+              "requires": {
+                "default-require-extensions": "^2.0.0"
+              }
+            },
+            "archy": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
+              "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA="
+            },
+            "arrify": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+              "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
+            },
+            "balanced-match": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+              "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+            },
+            "brace-expansion": {
+              "version": "1.1.11",
+              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+              "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+              "requires": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+              }
+            },
+            "caching-transform": {
+              "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-3.0.1.tgz",
+              "integrity": "sha512-Y1KTLNwSPd4ljsDrFOtyXVmm7Gnk42yQitNq43AhE+cwUR/e4T+rmOHs1IPtzBg8066GBJfTOj1rQYFSWSsH2g==",
+              "requires": {
+                "hasha": "^3.0.0",
+                "make-dir": "^1.3.0",
+                "package-hash": "^3.0.0",
+                "write-file-atomic": "^2.3.0"
+              }
+            },
+            "camelcase": {
+              "version": "5.0.0",
+              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.0.0.tgz",
+              "integrity": "sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA=="
+            },
+            "cliui": {
+              "version": "4.1.0",
+              "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
+              "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
+              "requires": {
+                "string-width": "^2.1.1",
+                "strip-ansi": "^4.0.0",
+                "wrap-ansi": "^2.0.0"
+              }
+            },
+            "code-point-at": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+              "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+            },
+            "commondir": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+              "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs="
+            },
+            "concat-map": {
+              "version": "0.0.1",
+              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+              "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+            },
+            "convert-source-map": {
+              "version": "1.6.0",
+              "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz",
+              "integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
+              "requires": {
+                "safe-buffer": "~5.1.1"
+              }
+            },
+            "cross-spawn": {
+              "version": "4.0.2",
+              "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
+              "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
+              "requires": {
+                "lru-cache": "^4.0.1",
+                "which": "^1.2.9"
+              }
+            },
+            "debug": {
+              "version": "4.1.1",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+              "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+              "requires": {
+                "ms": "^2.1.1"
+              }
+            },
+            "decamelize": {
+              "version": "1.2.0",
+              "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+              "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+            },
+            "default-require-extensions": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-2.0.0.tgz",
+              "integrity": "sha1-9fj7sYp9bVCyH2QfZJ67Uiz+JPc=",
+              "requires": {
+                "strip-bom": "^3.0.0"
+              }
+            },
+            "end-of-stream": {
+              "version": "1.4.1",
+              "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
+              "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+              "requires": {
+                "once": "^1.4.0"
+              }
+            },
+            "error-ex": {
+              "version": "1.3.2",
+              "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+              "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+              "requires": {
+                "is-arrayish": "^0.2.1"
+              }
+            },
+            "es6-error": {
+              "version": "4.1.1",
+              "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
+              "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg=="
+            },
+            "execa": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+              "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+              "requires": {
+                "cross-spawn": "^6.0.0",
+                "get-stream": "^4.0.0",
+                "is-stream": "^1.1.0",
+                "npm-run-path": "^2.0.0",
+                "p-finally": "^1.0.0",
+                "signal-exit": "^3.0.0",
+                "strip-eof": "^1.0.0"
+              },
+              "dependencies": {
+                "cross-spawn": {
+                  "version": "6.0.5",
+                  "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+                  "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+                  "requires": {
+                    "nice-try": "^1.0.4",
+                    "path-key": "^2.0.1",
+                    "semver": "^5.5.0",
+                    "shebang-command": "^1.2.0",
+                    "which": "^1.2.9"
+                  }
+                }
+              }
+            },
+            "find-cache-dir": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.0.0.tgz",
+              "integrity": "sha512-LDUY6V1Xs5eFskUVYtIwatojt6+9xC9Chnlk/jYOOvn3FAFfSaWddxahDGyNHh0b2dMXa6YW2m0tk8TdVaXHlA==",
+              "requires": {
+                "commondir": "^1.0.1",
+                "make-dir": "^1.0.0",
+                "pkg-dir": "^3.0.0"
+              }
+            },
+            "find-up": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+              "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+              "requires": {
+                "locate-path": "^3.0.0"
+              }
+            },
+            "foreground-child": {
+              "version": "1.5.6",
+              "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-1.5.6.tgz",
+              "integrity": "sha1-T9ca0t/elnibmApcCilZN8svXOk=",
+              "requires": {
+                "cross-spawn": "^4",
+                "signal-exit": "^3.0.0"
+              }
+            },
+            "fs.realpath": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+              "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+            },
+            "get-caller-file": {
+              "version": "1.0.3",
+              "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
+              "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w=="
+            },
+            "get-stream": {
+              "version": "4.1.0",
+              "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+              "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+              "requires": {
+                "pump": "^3.0.0"
+              }
+            },
+            "glob": {
+              "version": "7.1.3",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+              "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+              "requires": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+              }
+            },
+            "graceful-fs": {
+              "version": "4.1.15",
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
+              "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA=="
+            },
+            "has-flag": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+              "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+            },
+            "hasha": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/hasha/-/hasha-3.0.0.tgz",
+              "integrity": "sha1-UqMvq4Vp1BymmmH/GiFPjrfIvTk=",
+              "requires": {
+                "is-stream": "^1.0.1"
+              }
+            },
+            "hosted-git-info": {
+              "version": "2.7.1",
+              "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
+              "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w=="
+            },
+            "imurmurhash": {
+              "version": "0.1.4",
+              "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+              "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
+            },
+            "inflight": {
+              "version": "1.0.6",
+              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+              "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+              "requires": {
+                "once": "^1.3.0",
+                "wrappy": "1"
+              }
+            },
+            "inherits": {
+              "version": "2.0.3",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+            },
+            "invert-kv": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
+              "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA=="
+            },
+            "is-arrayish": {
+              "version": "0.2.1",
+              "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+              "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
+            },
+            "is-fullwidth-code-point": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+              "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+            },
+            "is-stream": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+              "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+            },
+            "isexe": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+              "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+            },
+            "istanbul-lib-coverage": {
+              "version": "2.0.3",
+              "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz",
+              "integrity": "sha512-dKWuzRGCs4G+67VfW9pBFFz2Jpi4vSp/k7zBcJ888ofV5Mi1g5CUML5GvMvV6u9Cjybftu+E8Cgp+k0dI1E5lw=="
+            },
+            "istanbul-lib-hook": {
+              "version": "2.0.3",
+              "resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-2.0.3.tgz",
+              "integrity": "sha512-CLmEqwEhuCYtGcpNVJjLV1DQyVnIqavMLFHV/DP+np/g3qvdxu3gsPqYoJMXm15sN84xOlckFB3VNvRbf5yEgA==",
+              "requires": {
+                "append-transform": "^1.0.0"
+              }
+            },
+            "istanbul-lib-report": {
+              "version": "2.0.4",
+              "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-2.0.4.tgz",
+              "integrity": "sha512-sOiLZLAWpA0+3b5w5/dq0cjm2rrNdAfHWaGhmn7XEFW6X++IV9Ohn+pnELAl9K3rfpaeBfbmH9JU5sejacdLeA==",
+              "requires": {
+                "istanbul-lib-coverage": "^2.0.3",
+                "make-dir": "^1.3.0",
+                "supports-color": "^6.0.0"
+              },
+              "dependencies": {
+                "supports-color": {
+                  "version": "6.1.0",
+                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+                  "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+                  "requires": {
+                    "has-flag": "^3.0.0"
+                  }
+                }
+              }
+            },
+            "istanbul-lib-source-maps": {
+              "version": "3.0.2",
+              "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-3.0.2.tgz",
+              "integrity": "sha512-JX4v0CiKTGp9fZPmoxpu9YEkPbEqCqBbO3403VabKjH+NRXo72HafD5UgnjTEqHL2SAjaZK1XDuDOkn6I5QVfQ==",
+              "requires": {
+                "debug": "^4.1.1",
+                "istanbul-lib-coverage": "^2.0.3",
+                "make-dir": "^1.3.0",
+                "rimraf": "^2.6.2",
+                "source-map": "^0.6.1"
+              },
+              "dependencies": {
+                "source-map": {
+                  "version": "0.6.1",
+                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                  "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+                }
+              }
+            },
+            "istanbul-reports": {
+              "version": "2.1.1",
+              "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-2.1.1.tgz",
+              "integrity": "sha512-FzNahnidyEPBCI0HcufJoSEoKykesRlFcSzQqjH9x0+LC8tnnE/p/90PBLu8iZTxr8yYZNyTtiAujUqyN+CIxw==",
+              "requires": {
+                "handlebars": "^4.1.0"
+              }
+            },
+            "json-parse-better-errors": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+              "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw=="
+            },
+            "lcid": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
+              "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
+              "requires": {
+                "invert-kv": "^2.0.0"
+              }
+            },
+            "load-json-file": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+              "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+              "requires": {
+                "graceful-fs": "^4.1.2",
+                "parse-json": "^4.0.0",
+                "pify": "^3.0.0",
+                "strip-bom": "^3.0.0"
+              }
+            },
+            "locate-path": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+              "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+              "requires": {
+                "p-locate": "^3.0.0",
+                "path-exists": "^3.0.0"
+              }
+            },
+            "lodash.flattendeep": {
+              "version": "4.4.0",
+              "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
+              "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI="
+            },
+            "lru-cache": {
+              "version": "4.1.5",
+              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+              "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+              "requires": {
+                "pseudomap": "^1.0.2",
+                "yallist": "^2.1.2"
+              }
+            },
+            "make-dir": {
+              "version": "1.3.0",
+              "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
+              "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
+              "requires": {
+                "pify": "^3.0.0"
+              }
+            },
+            "map-age-cleaner": {
+              "version": "0.1.3",
+              "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
+              "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
+              "requires": {
+                "p-defer": "^1.0.0"
+              }
+            },
+            "mem": {
+              "version": "4.1.0",
+              "resolved": "https://registry.npmjs.org/mem/-/mem-4.1.0.tgz",
+              "integrity": "sha512-I5u6Q1x7wxO0kdOpYBB28xueHADYps5uty/zg936CiG8NTe5sJL8EjrCuLneuDW3PlMdZBGDIn8BirEVdovZvg==",
+              "requires": {
+                "map-age-cleaner": "^0.1.1",
+                "mimic-fn": "^1.0.0",
+                "p-is-promise": "^2.0.0"
+              }
+            },
+            "merge-source-map": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/merge-source-map/-/merge-source-map-1.1.0.tgz",
+              "integrity": "sha512-Qkcp7P2ygktpMPh2mCQZaf3jhN6D3Z/qVZHSdWvQ+2Ef5HgRAPBO57A77+ENm0CPx2+1Ce/MYKi3ymqdfuqibw==",
+              "requires": {
+                "source-map": "^0.6.1"
+              },
+              "dependencies": {
+                "source-map": {
+                  "version": "0.6.1",
+                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                  "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+                }
+              }
+            },
+            "mimic-fn": {
+              "version": "1.2.0",
+              "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+              "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
+            },
+            "minimatch": {
+              "version": "3.0.4",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+              "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+              "requires": {
+                "brace-expansion": "^1.1.7"
+              }
+            },
+            "mkdirp": {
+              "version": "0.5.1",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+              "requires": {
+                "minimist": "0.0.8"
+              },
+              "dependencies": {
+                "minimist": {
+                  "version": "0.0.8",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                  "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+                }
+              }
+            },
+            "ms": {
+              "version": "2.1.1",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+              "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+            },
+            "nice-try": {
+              "version": "1.0.5",
+              "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+              "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
+            },
+            "normalize-package-data": {
+              "version": "2.5.0",
+              "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+              "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+              "requires": {
+                "hosted-git-info": "^2.1.4",
+                "resolve": "^1.10.0",
+                "semver": "2 || 3 || 4 || 5",
+                "validate-npm-package-license": "^3.0.1"
+              }
+            },
+            "npm-run-path": {
+              "version": "2.0.2",
+              "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+              "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+              "requires": {
+                "path-key": "^2.0.0"
+              }
+            },
+            "number-is-nan": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+              "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+            },
+            "once": {
+              "version": "1.4.0",
+              "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+              "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+              "requires": {
+                "wrappy": "1"
+              }
+            },
+            "os-homedir": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+              "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
+            },
+            "os-locale": {
+              "version": "3.1.0",
+              "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
+              "integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
+              "requires": {
+                "execa": "^1.0.0",
+                "lcid": "^2.0.0",
+                "mem": "^4.0.0"
+              }
+            },
+            "p-defer": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
+              "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww="
+            },
+            "p-finally": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+              "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
+            },
+            "p-is-promise": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.0.0.tgz",
+              "integrity": "sha512-pzQPhYMCAgLAKPWD2jC3Se9fEfrD9npNos0y150EeqZll7akhEgGhTW/slB6lHku8AvYGiJ+YJ5hfHKePPgFWg=="
+            },
+            "p-limit": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.1.0.tgz",
+              "integrity": "sha512-NhURkNcrVB+8hNfLuysU8enY5xn2KXphsHBaC2YmRNTZRc7RWusw6apSpdEj3jo4CMb6W9nrF6tTnsJsJeyu6g==",
+              "requires": {
+                "p-try": "^2.0.0"
+              }
+            },
+            "p-locate": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+              "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+              "requires": {
+                "p-limit": "^2.0.0"
+              }
+            },
+            "p-try": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz",
+              "integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ=="
+            },
+            "package-hash": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/package-hash/-/package-hash-3.0.0.tgz",
+              "integrity": "sha512-lOtmukMDVvtkL84rJHI7dpTYq+0rli8N2wlnqUcBuDWCfVhRUfOmnR9SsoHFMLpACvEV60dX7rd0rFaYDZI+FA==",
+              "requires": {
+                "graceful-fs": "^4.1.15",
+                "hasha": "^3.0.0",
+                "lodash.flattendeep": "^4.4.0",
+                "release-zalgo": "^1.0.0"
+              }
+            },
+            "parse-json": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+              "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+              "requires": {
+                "error-ex": "^1.3.1",
+                "json-parse-better-errors": "^1.0.1"
+              }
+            },
+            "path-exists": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+              "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
+            },
+            "path-is-absolute": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+              "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+            },
+            "path-key": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+              "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
+            },
+            "path-parse": {
+              "version": "1.0.6",
+              "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+              "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
+            },
+            "path-type": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+              "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+              "requires": {
+                "pify": "^3.0.0"
+              }
+            },
+            "pify": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+              "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+            },
+            "pkg-dir": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
+              "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
+              "requires": {
+                "find-up": "^3.0.0"
+              }
+            },
+            "pseudomap": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+              "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+            },
+            "pump": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+              "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+              "requires": {
+                "end-of-stream": "^1.1.0",
+                "once": "^1.3.1"
+              }
+            },
+            "read-pkg": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+              "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+              "requires": {
+                "load-json-file": "^4.0.0",
+                "normalize-package-data": "^2.3.2",
+                "path-type": "^3.0.0"
+              }
+            },
+            "read-pkg-up": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-4.0.0.tgz",
+              "integrity": "sha512-6etQSH7nJGsK0RbG/2TeDzZFa8shjQ1um+SwQQ5cwKy0dhSXdOncEhb1CPpvQG4h7FyOV6EB6YlV0yJvZQNAkA==",
+              "requires": {
+                "find-up": "^3.0.0",
+                "read-pkg": "^3.0.0"
+              }
+            },
+            "release-zalgo": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/release-zalgo/-/release-zalgo-1.0.0.tgz",
+              "integrity": "sha1-CXALflB0Mpc5Mw5TXFqQ+2eFFzA=",
+              "requires": {
+                "es6-error": "^4.0.1"
+              }
+            },
+            "require-directory": {
+              "version": "2.1.1",
+              "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+              "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
+            },
+            "require-main-filename": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+              "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
+            },
+            "resolve": {
+              "version": "1.10.0",
+              "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
+              "integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
+              "requires": {
+                "path-parse": "^1.0.6"
+              }
+            },
+            "resolve-from": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+              "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="
+            },
+            "rimraf": {
+              "version": "2.6.3",
+              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+              "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+              "requires": {
+                "glob": "^7.1.3"
+              }
+            },
+            "safe-buffer": {
+              "version": "5.1.2",
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+            },
+            "semver": {
+              "version": "5.6.0",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
+              "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg=="
+            },
+            "set-blocking": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+              "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+            },
+            "shebang-command": {
+              "version": "1.2.0",
+              "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+              "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+              "requires": {
+                "shebang-regex": "^1.0.0"
+              }
+            },
+            "shebang-regex": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+              "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
+            },
+            "signal-exit": {
+              "version": "3.0.2",
+              "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+              "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+            },
+            "spawn-wrap": {
+              "version": "1.4.2",
+              "resolved": "https://registry.npmjs.org/spawn-wrap/-/spawn-wrap-1.4.2.tgz",
+              "integrity": "sha512-vMwR3OmmDhnxCVxM8M+xO/FtIp6Ju/mNaDfCMMW7FDcLRTPFWUswec4LXJHTJE2hwTI9O0YBfygu4DalFl7Ylg==",
+              "requires": {
+                "foreground-child": "^1.5.6",
+                "mkdirp": "^0.5.0",
+                "os-homedir": "^1.0.1",
+                "rimraf": "^2.6.2",
+                "signal-exit": "^3.0.2",
+                "which": "^1.3.0"
+              }
+            },
+            "spdx-correct": {
+              "version": "3.1.0",
+              "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
+              "integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
+              "requires": {
+                "spdx-expression-parse": "^3.0.0",
+                "spdx-license-ids": "^3.0.0"
+              }
+            },
+            "spdx-exceptions": {
+              "version": "2.2.0",
+              "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
+              "integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA=="
+            },
+            "spdx-expression-parse": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+              "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+              "requires": {
+                "spdx-exceptions": "^2.1.0",
+                "spdx-license-ids": "^3.0.0"
+              }
+            },
+            "spdx-license-ids": {
+              "version": "3.0.3",
+              "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.3.tgz",
+              "integrity": "sha512-uBIcIl3Ih6Phe3XHK1NqboJLdGfwr1UN3k6wSD1dZpmPsIkb8AGNbZYJ1fOBk834+Gxy8rpfDxrS6XLEMZMY2g=="
+            },
+            "string-width": {
+              "version": "2.1.1",
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+              "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+              "requires": {
+                "is-fullwidth-code-point": "^2.0.0",
+                "strip-ansi": "^4.0.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+              "requires": {
+                "ansi-regex": "^3.0.0"
+              }
+            },
+            "strip-bom": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+              "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
+            },
+            "strip-eof": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+              "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
+            },
+            "test-exclude": {
+              "version": "5.1.0",
+              "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-5.1.0.tgz",
+              "integrity": "sha512-gwf0S2fFsANC55fSeSqpb8BYk6w3FDvwZxfNjeF6FRgvFa43r+7wRiA/Q0IxoRU37wB/LE8IQ4221BsNucTaCA==",
+              "requires": {
+                "arrify": "^1.0.1",
+                "minimatch": "^3.0.4",
+                "read-pkg-up": "^4.0.0",
+                "require-main-filename": "^1.0.1"
+              }
+            },
+            "uuid": {
+              "version": "3.3.2",
+              "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+              "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+            },
+            "validate-npm-package-license": {
+              "version": "3.0.4",
+              "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+              "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+              "requires": {
+                "spdx-correct": "^3.0.0",
+                "spdx-expression-parse": "^3.0.0"
+              }
+            },
+            "which": {
+              "version": "1.3.1",
+              "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+              "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+              "requires": {
+                "isexe": "^2.0.0"
+              }
+            },
+            "which-module": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+              "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
+            },
+            "wrap-ansi": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+              "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+              "requires": {
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1"
+              },
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "2.1.1",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                  "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+                },
+                "is-fullwidth-code-point": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                  "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+                  "requires": {
+                    "number-is-nan": "^1.0.0"
+                  }
+                },
+                "string-width": {
+                  "version": "1.0.2",
+                  "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+                  "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+                  "requires": {
+                    "code-point-at": "^1.0.0",
+                    "is-fullwidth-code-point": "^1.0.0",
+                    "strip-ansi": "^3.0.0"
+                  }
+                },
+                "strip-ansi": {
+                  "version": "3.0.1",
+                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                  "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+                  "requires": {
+                    "ansi-regex": "^2.0.0"
+                  }
+                }
+              }
+            },
+            "wrappy": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+              "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+            },
+            "write-file-atomic": {
+              "version": "2.4.2",
+              "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.2.tgz",
+              "integrity": "sha512-s0b6vB3xIVRLWywa6X9TOMA7k9zio0TMOsl9ZnDkliA/cfJlpHXAscj0gbHVJiTdIuAYpIyqS5GW91fqm6gG5g==",
+              "requires": {
+                "graceful-fs": "^4.1.11",
+                "imurmurhash": "^0.1.4",
+                "signal-exit": "^3.0.2"
+              }
+            },
+            "y18n": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+              "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
+            },
+            "yallist": {
+              "version": "2.1.2",
+              "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+              "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+            },
+            "yargs": {
+              "version": "12.0.5",
+              "resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
+              "integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
+              "requires": {
+                "cliui": "^4.0.0",
+                "decamelize": "^1.2.0",
+                "find-up": "^3.0.0",
+                "get-caller-file": "^1.0.1",
+                "os-locale": "^3.0.0",
+                "require-directory": "^2.1.1",
+                "require-main-filename": "^1.0.1",
+                "set-blocking": "^2.0.0",
+                "string-width": "^2.0.0",
+                "which-module": "^2.0.0",
+                "y18n": "^3.2.1 || ^4.0.0",
+                "yargs-parser": "^11.1.1"
+              }
+            },
+            "yargs-parser": {
+              "version": "11.1.1",
+              "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
+              "integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
+              "requires": {
+                "camelcase": "^5.0.0",
+                "decamelize": "^1.2.0"
+              }
+            }
+          }
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+        },
+        "object-copy": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
+          "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
+          "requires": {
+            "copy-descriptor": "^0.1.0",
+            "define-property": "^0.2.5",
+            "kind-of": "^3.0.3"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "0.2.5",
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+              "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+              "requires": {
+                "is-descriptor": "^0.1.0"
+              }
+            }
+          }
+        },
+        "object-inspect": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.6.0.tgz",
+          "integrity": "sha512-GJzfBZ6DgDAmnuaM3104jR4s1Myxr3Y3zfIyN4z3UdqN69oSRacNK8UhnobDdC+7J2AHCjGwxQubNJfE70SXXQ=="
+        },
+        "object-keys": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+          "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
+        },
+        "object-visit": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
+          "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
+          "requires": {
+            "isobject": "^3.0.0"
+          },
+          "dependencies": {
+            "isobject": {
+              "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+              "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+            }
+          }
+        },
+        "object.omit": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+          "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
+          "requires": {
+            "for-own": "^0.1.4",
+            "is-extendable": "^0.1.1"
+          }
+        },
+        "object.pick": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
+          "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+          "requires": {
+            "isobject": "^3.0.1"
+          },
+          "dependencies": {
+            "isobject": {
+              "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+              "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+            }
+          }
+        },
+        "observ": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/observ/-/observ-0.2.0.tgz",
+          "integrity": "sha1-C8ObPin6pfnmyqWQbLg5LfQAqmg="
+        },
+        "observ-debounce": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/observ-debounce/-/observ-debounce-1.1.1.tgz",
+          "integrity": "sha1-ME6XyFrdpw7NfwjaRQZ475Dwtwc=",
+          "requires": {
+            "observ": "~0.2.0"
+          }
+        },
+        "obv": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/obv/-/obv-0.0.1.tgz",
+          "integrity": "sha1-yyNhBjQVNvDaxIFeBnCCIcrX+14="
+        },
+        "on-change-network": {
+          "version": "0.0.2",
+          "resolved": "https://registry.npmjs.org/on-change-network/-/on-change-network-0.0.2.tgz",
+          "integrity": "sha1-2XcklHf5FyaUnYDoI0batu9FIWs="
+        },
+        "on-wakeup": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/on-wakeup/-/on-wakeup-1.0.1.tgz",
+          "integrity": "sha1-ANedmH3efIEXvudLtJA/b22vpSs="
+        },
+        "once": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+          "requires": {
+            "wrappy": "1"
+          }
+        },
+        "onetime": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+          "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k="
+        },
+        "opencollective-postinstall": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/opencollective-postinstall/-/opencollective-postinstall-2.0.2.tgz",
+          "integrity": "sha512-pVOEP16TrAO2/fjej1IdOyupJY8KDUM1CvsaScRbw6oddvpQoOfGk4ywha0HKKVAD6RkW4x6Q+tNBwhf3Bgpuw=="
+        },
+        "optimist": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+          "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+          "requires": {
+            "minimist": "~0.0.1",
+            "wordwrap": "~0.0.2"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.10",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+              "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8="
+            }
+          }
+        },
+        "options": {
+          "version": "0.0.6",
+          "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",
+          "integrity": "sha1-7CLTEoBrtT5zF3Pnza788cZDEo8="
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
+        },
+        "os-tmpdir": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+          "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+        },
+        "osenv": {
+          "version": "0.1.5",
+          "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+          "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
+          "requires": {
+            "os-homedir": "^1.0.0",
+            "os-tmpdir": "^1.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+          "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+          "requires": {
+            "p-try": "^1.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+          "requires": {
+            "p-limit": "^1.1.0"
+          }
+        },
+        "p-try": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
+        },
+        "packet-stream": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/packet-stream/-/packet-stream-2.0.4.tgz",
+          "integrity": "sha512-7+oxHdMMs6VhLvvbrDUc8QNuelE9fPKLDdToXBIKLPKOlnoBeMim+/35edp+AnFTLzk3xcogVvQ/jrZyyGsEiw=="
+        },
+        "packet-stream-codec": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/packet-stream-codec/-/packet-stream-codec-1.1.2.tgz",
+          "integrity": "sha1-ebMC/BRM37tKtv66cEDmpdmcecc=",
+          "requires": {
+            "pull-reader": "^1.2.4",
+            "pull-through": "^1.0.17"
+          }
+        },
+        "parse-entities": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-1.2.2.tgz",
+          "integrity": "sha512-NzfpbxW/NPrzZ/yYSoQxyqUZMZXIdCfE0OIN4ESsnptHJECoUk3FZktxNuzQf4tjt5UEopnxpYJbvYuxIFDdsg==",
+          "requires": {
+            "character-entities": "^1.0.0",
+            "character-entities-legacy": "^1.0.0",
+            "character-reference-invalid": "^1.0.0",
+            "is-alphanumerical": "^1.0.0",
+            "is-decimal": "^1.0.0",
+            "is-hexadecimal": "^1.0.0"
+          }
+        },
+        "parse-glob": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+          "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+          "requires": {
+            "glob-base": "^0.3.0",
+            "is-dotfile": "^1.0.0",
+            "is-extglob": "^1.0.0",
+            "is-glob": "^2.0.0"
+          }
+        },
+        "parse-json": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+          "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+          "requires": {
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1"
+          }
+        },
+        "pascalcase": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
+          "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ="
+        },
+        "path-exists": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+        },
+        "path-key": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+          "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
+        },
+        "path-parse": {
+          "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+          "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
+        },
+        "path-type": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+          "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+          "requires": {
+            "pify": "^3.0.0"
+          },
+          "dependencies": {
+            "pify": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+              "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+            }
+          }
+        },
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+        },
+        "pinkie": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+          "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
+        },
+        "pinkie-promise": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+          "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+          "requires": {
+            "pinkie": "^2.0.0"
+          }
+        },
+        "plur": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/plur/-/plur-2.1.2.tgz",
+          "integrity": "sha1-dIJFLBoPUI4+NE6uwxLJHCncZVo=",
+          "requires": {
+            "irregular-plurals": "^1.0.0"
+          }
+        },
+        "posix-character-classes": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
+          "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
+        },
+        "preserve": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
+          "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
+        },
+        "private-box": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/private-box/-/private-box-0.3.0.tgz",
+          "integrity": "sha512-zsK6DDEC+cnNiunYamcVbx4ZCLbKnzTOZa09K4Pj3/tH3nQFPUO9K2QoYy4kfxLqmoyw6RPDtACN9OYviMQZ2Q==",
+          "requires": {
+            "chloride": "^2.2.9"
+          }
+        },
+        "process-nextick-args": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+          "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+        },
+        "promisize": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/promisize/-/promisize-1.1.2.tgz",
+          "integrity": "sha1-m0fiyyrkl+seutwsQZHWTRXJSdE="
+        },
+        "prr": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
+          "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY="
+        },
+        "pull-abortable": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/pull-abortable/-/pull-abortable-4.1.1.tgz",
+          "integrity": "sha1-s61a77QRayWRbSbbiTk6yY0NzqE="
+        },
+        "pull-bitflipper": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/pull-bitflipper/-/pull-bitflipper-0.1.0.tgz",
+          "integrity": "sha1-rGaxvyWd/qK/BOcMGOfYwgfXAx0=",
+          "requires": {
+            "pull-stream": "~2.27.0"
+          },
+          "dependencies": {
+            "pull-stream": {
+              "version": "2.27.0",
+              "resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-2.27.0.tgz",
+              "integrity": "sha1-/fDrkQzcQEHWWVbAC+4w270AoGg=",
+              "requires": {
+                "pull-core": "~1.1.0"
+              }
+            }
+          }
+        },
+        "pull-box-stream": {
+          "version": "1.0.13",
+          "resolved": "https://registry.npmjs.org/pull-box-stream/-/pull-box-stream-1.0.13.tgz",
+          "integrity": "sha1-w+JAOY6rP1lRsu0QeMWYi/egork=",
+          "requires": {
+            "chloride": "^2.2.7",
+            "increment-buffer": "~1.0.0",
+            "pull-reader": "^1.2.5",
+            "pull-stream": "^3.2.3",
+            "pull-through": "^1.0.18",
+            "split-buffer": "~1.0.0"
+          }
+        },
+        "pull-cat": {
+          "version": "1.1.11",
+          "resolved": "https://registry.npmjs.org/pull-cat/-/pull-cat-1.1.11.tgz",
+          "integrity": "sha1-tkLdElXaN2pwa220+pYvX9t0wxs="
+        },
+        "pull-catch": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/pull-catch/-/pull-catch-1.0.1.tgz",
+          "integrity": "sha512-wrKbmEYySNETxOYXDTCJ8L/rcAFMayOifne2a+X9C0wSm6ttIWHHXwMYQh6k8iDRvtMM8itYkBlP4leKBJTiKA=="
+        },
+        "pull-cont": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/pull-cont/-/pull-cont-0.1.1.tgz",
+          "integrity": "sha1-3x1YDicXV7qay666IN4kIdZg1hg="
+        },
+        "pull-core": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/pull-core/-/pull-core-1.1.0.tgz",
+          "integrity": "sha1-PYEn1trBR1cFyYAJYfWdZsgEbIo="
+        },
+        "pull-cursor": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pull-cursor/-/pull-cursor-3.0.0.tgz",
+          "integrity": "sha512-95lZVSF2eSEdOmUtlOBaD9p5YOvlYeCr5FBv2ySqcj/4rpaXI6d8OH+zPHHjKAf58R8QXJRZuyfHkcCX8TZbAg==",
+          "requires": {
+            "looper": "^4.0.0",
+            "ltgt": "^2.2.0",
+            "pull-stream": "^3.6.0"
+          }
+        },
+        "pull-defer": {
+          "version": "0.2.3",
+          "resolved": "https://registry.npmjs.org/pull-defer/-/pull-defer-0.2.3.tgz",
+          "integrity": "sha512-/An3KE7mVjZCqNhZsr22k1Tx8MACnUnHZZNPSJ0S62td8JtYr/AiRG42Vz7Syu31SoTLUzVIe61jtT/pNdjVYA=="
+        },
+        "pull-file": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/pull-file/-/pull-file-1.1.0.tgz",
+          "integrity": "sha1-HdmHYF1jV6DSPB5Lgm95FaIVEpw=",
+          "requires": {
+            "pull-utf8-decoder": "^1.0.2"
+          }
+        },
+        "pull-flatmap": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/pull-flatmap/-/pull-flatmap-0.0.1.tgz",
+          "integrity": "sha1-E9SURT6PbUeOe7+t5vj+AZf6a7c="
+        },
+        "pull-fs": {
+          "version": "1.1.6",
+          "resolved": "https://registry.npmjs.org/pull-fs/-/pull-fs-1.1.6.tgz",
+          "integrity": "sha1-8YT2p3KLtNlWQTdr6tafb2bfR80=",
+          "requires": {
+            "pull-file": "^0.5.0",
+            "pull-stream": "^3.3.0",
+            "pull-traverse": "^1.0.3",
+            "pull-write-file": "^0.2.1"
+          },
+          "dependencies": {
+            "pull-file": {
+              "version": "0.5.0",
+              "resolved": "https://registry.npmjs.org/pull-file/-/pull-file-0.5.0.tgz",
+              "integrity": "sha1-s8pAUwbggvnUUoKIkzutsrZWNls=",
+              "requires": {
+                "pull-utf8-decoder": "^1.0.2"
+              }
+            }
+          }
+        },
+        "pull-glob": {
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/pull-glob/-/pull-glob-1.0.7.tgz",
+          "integrity": "sha1-7vkV3eZEvdvqjdLgEG1USqy81cI=",
+          "requires": {
+            "pull-fs": "~1.1.6",
+            "pull-stream": "^3.3.0"
+          }
+        },
+        "pull-goodbye": {
+          "version": "0.0.2",
+          "resolved": "https://registry.npmjs.org/pull-goodbye/-/pull-goodbye-0.0.2.tgz",
+          "integrity": "sha1-jYNX21XiKnEN//DxaoyQtF7+QXE=",
+          "requires": {
+            "pull-stream": "~3.5.0"
+          },
+          "dependencies": {
+            "pull-stream": {
+              "version": "3.5.0",
+              "resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-3.5.0.tgz",
+              "integrity": "sha1-HuW292/Ts6SaWvtt7VwDIKyzz8c="
+            }
+          }
+        },
+        "pull-handshake": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/pull-handshake/-/pull-handshake-1.1.4.tgz",
+          "integrity": "sha1-YACg/QGIhM39c3JU+Mxgqypjd5E=",
+          "requires": {
+            "pull-cat": "^1.1.9",
+            "pull-pair": "~1.1.0",
+            "pull-pushable": "^2.0.0",
+            "pull-reader": "^1.2.3"
+          }
+        },
+        "pull-hash": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/pull-hash/-/pull-hash-1.0.0.tgz",
+          "integrity": "sha1-/K1NJQe/LCsyMfZT3Jv7LbTw2Iw="
+        },
+        "pull-inactivity": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/pull-inactivity/-/pull-inactivity-2.1.3.tgz",
+          "integrity": "sha512-swJ/jwkIN/O1bQCE3iY7Xy9r3gYuJ50MXaxZilw/HIduAy4tJu+vcz2/If0L+xNK7Ku/FfjtVbTpRTe7sf3hmA==",
+          "requires": {
+            "pull-abortable": "~4.0.0",
+            "pull-stream": "^3.4.5"
+          },
+          "dependencies": {
+            "pull-abortable": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/pull-abortable/-/pull-abortable-4.0.0.tgz",
+              "integrity": "sha1-cBephMO4NN53usOMELd28i38GEM="
+            }
+          }
+        },
+        "pull-level": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/pull-level/-/pull-level-2.0.4.tgz",
+          "integrity": "sha512-fW6pljDeUThpq5KXwKbRG3X7Ogk3vc75d5OQU/TvXXui65ykm+Bn+fiktg+MOx2jJ85cd+sheufPL+rw9QSVZg==",
+          "requires": {
+            "level-post": "^1.0.7",
+            "pull-cat": "^1.1.9",
+            "pull-live": "^1.0.1",
+            "pull-pushable": "^2.0.0",
+            "pull-stream": "^3.4.0",
+            "pull-window": "^2.1.4",
+            "stream-to-pull-stream": "^1.7.1"
+          }
+        },
+        "pull-live": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/pull-live/-/pull-live-1.0.1.tgz",
+          "integrity": "sha1-pOzuAeMwFV6RJLu89HYfIbOPUfU=",
+          "requires": {
+            "pull-cat": "^1.1.9",
+            "pull-stream": "^3.4.0"
+          }
+        },
+        "pull-looper": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/pull-looper/-/pull-looper-1.0.0.tgz",
+          "integrity": "sha512-djlD60A6NGe5goLdP5pgbqzMEiWmk1bInuAzBp0QOH4vDrVwh05YDz6UP8+pOXveKEk8wHVP+rB2jBrK31QMPA==",
+          "requires": {
+            "looper": "^4.0.0"
+          }
+        },
+        "pull-many": {
+          "version": "1.0.8",
+          "resolved": "https://registry.npmjs.org/pull-many/-/pull-many-1.0.8.tgz",
+          "integrity": "sha1-Pa3ZttFWxUVyG9qNAAPdjqoGKT4=",
+          "requires": {
+            "pull-stream": "^3.4.5"
+          }
+        },
+        "pull-next": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/pull-next/-/pull-next-1.0.1.tgz",
+          "integrity": "sha1-A/TX0Zhy/BEUFh6I227PTGXmHlY="
+        },
+        "pull-notify": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/pull-notify/-/pull-notify-0.1.1.tgz",
+          "integrity": "sha1-b4b/ldJwuJw+vyVbYDG3Ay3JnMo=",
+          "requires": {
+            "pull-pushable": "^2.0.0"
+          }
+        },
+        "pull-pair": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/pull-pair/-/pull-pair-1.1.0.tgz",
+          "integrity": "sha1-fuQnJj/fTaglOXrAoF4atLdL120="
+        },
+        "pull-paramap": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/pull-paramap/-/pull-paramap-1.2.2.tgz",
+          "integrity": "sha1-UaQZPOnI1yFdla2tReK824STsjo=",
+          "requires": {
+            "looper": "^4.0.0"
+          }
+        },
+        "pull-ping": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/pull-ping/-/pull-ping-2.0.2.tgz",
+          "integrity": "sha1-e8SjQBZ9rYj2gqGWxjSFc1x6CJQ=",
+          "requires": {
+            "pull-pushable": "^2.0.0",
+            "pull-stream": "^3.4.5",
+            "statistics": "^3.3.0"
+          }
+        },
+        "pull-pushable": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/pull-pushable/-/pull-pushable-2.2.0.tgz",
+          "integrity": "sha1-Xy867UethpGfAbEqLpnW8b13ZYE="
+        },
+        "pull-rate": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/pull-rate/-/pull-rate-1.0.2.tgz",
+          "integrity": "sha1-F7IxrV81n2dYJmcBcrDlkMiWTo0=",
+          "requires": {
+            "pull-stream": "^3.6.0"
+          }
+        },
+        "pull-reader": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/pull-reader/-/pull-reader-1.3.1.tgz",
+          "integrity": "sha512-CBkejkE5nX50SiSEzu0Qoz4POTJMS/mw8G6aj3h3M/RJoKgggLxyF0IyTZ0mmpXFlXRcLmLmIEW4xeYn7AeDYw=="
+        },
+        "pull-sink-through": {
+          "version": "0.0.0",
+          "resolved": "https://registry.npmjs.org/pull-sink-through/-/pull-sink-through-0.0.0.tgz",
+          "integrity": "sha1-08BJLzqAtO0gSvZ8S0+TVoD8Wx8="
+        },
+        "pull-sort": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/pull-sort/-/pull-sort-1.0.2.tgz",
+          "integrity": "sha512-jGcAHMP+0Le+bEIhSODlbNNd3jW+S6XrXOlhVzfcKU5HQZjP92OzQSgHHSlwvWRsiTWi+UGgbFpL/5gGgmFoVQ==",
+          "requires": {
+            "pull-defer": "^0.2.3",
+            "pull-stream": "^3.6.9"
+          }
+        },
+        "pull-stream": {
+          "version": "3.6.11",
+          "resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-3.6.11.tgz",
+          "integrity": "sha512-43brwtqO0OSltctKbW1mgzzKH4TNE8egkW+Y4BFzlDWiG2Ayl7VKr4SeuoKacfgPfUWcSwcPlHsf40BEqNR32A=="
+        },
+        "pull-through": {
+          "version": "1.0.18",
+          "resolved": "https://registry.npmjs.org/pull-through/-/pull-through-1.0.18.tgz",
+          "integrity": "sha1-jdYjFCY+Wc9Qlur7sSeitu8xBzU=",
+          "requires": {
+            "looper": "~3.0.0"
+          },
+          "dependencies": {
+            "looper": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/looper/-/looper-3.0.0.tgz",
+              "integrity": "sha1-LvpUw7HLq6m5Su4uWRSwvlf7t0k="
+            }
+          }
+        },
+        "pull-traverse": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/pull-traverse/-/pull-traverse-1.0.3.tgz",
+          "integrity": "sha1-dPtde+f6a9enjpeTPhmbeUWGaTg="
+        },
+        "pull-utf8-decoder": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/pull-utf8-decoder/-/pull-utf8-decoder-1.0.2.tgz",
+          "integrity": "sha1-p6+iOE0eZBWl1gIFQSbMjeO8vOc="
+        },
+        "pull-window": {
+          "version": "2.1.4",
+          "resolved": "https://registry.npmjs.org/pull-window/-/pull-window-2.1.4.tgz",
+          "integrity": "sha1-/DuG/uvRkgx64pdpHiP3BfiFUvA=",
+          "requires": {
+            "looper": "^2.0.0"
+          },
+          "dependencies": {
+            "looper": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/looper/-/looper-2.0.0.tgz",
+              "integrity": "sha1-Zs0Md0rz1P7axTeU90LbVtqPCew="
+            }
+          }
+        },
+        "pull-write": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/pull-write/-/pull-write-1.1.4.tgz",
+          "integrity": "sha1-3d6jFJO0j2douEooHQHrO1Mf4Lg=",
+          "requires": {
+            "looper": "^4.0.0",
+            "pull-cat": "^1.1.11",
+            "pull-stream": "^3.4.5"
+          }
+        },
+        "pull-write-file": {
+          "version": "0.2.4",
+          "resolved": "https://registry.npmjs.org/pull-write-file/-/pull-write-file-0.2.4.tgz",
+          "integrity": "sha1-Q3NErrIYn2XmeO0a838PdgpUU+8="
+        },
+        "pull-ws": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/pull-ws/-/pull-ws-3.3.2.tgz",
+          "integrity": "sha512-Bn4bcJsSzJGOQl4RBulDhG1FkcbDHSCXteI8Jg5k4X6X5TxVzZzKilWJ1WV2v4OnRXl2eYbtHFGsPl8Cr1xJzw==",
+          "requires": {
+            "relative-url": "^1.0.2",
+            "safe-buffer": "^5.1.1",
+            "ws": "^1.1.0"
+          }
+        },
+        "push-stream": {
+          "version": "10.0.4",
+          "resolved": "https://registry.npmjs.org/push-stream/-/push-stream-10.0.4.tgz",
+          "integrity": "sha512-IrP96RziNzT4UR7ZffM26o2NQ/Dq0dlRi1p8S/HE4+pHF6OaKWS1DyaJevsxJ6Q8bHafLqin6/pwI36FCmiV0w=="
+        },
+        "push-stream-to-pull-stream": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/push-stream-to-pull-stream/-/push-stream-to-pull-stream-1.0.3.tgz",
+          "integrity": "sha512-pdE/OKi/jnp9DqGgNRzLY0oVHffn/8TXJmBPzv+ikdvpkeA0J//l5d7TZk1yWwZj9P0JcOIEVDOuHzhXaeBlmw==",
+          "requires": {
+            "pull-looper": "^1.0.0",
+            "push-stream": "^10.0.3"
+          }
+        },
+        "quick-lru": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-1.1.0.tgz",
+          "integrity": "sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g="
+        },
+        "railroad-diagrams": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
+          "integrity": "sha1-635iZ1SN3t+4mcG5Dlc3RVnN234="
+        },
+        "randexp": {
+          "version": "0.4.6",
+          "resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.6.tgz",
+          "integrity": "sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==",
+          "requires": {
+            "discontinuous-range": "1.0.0",
+            "ret": "~0.1.10"
+          }
+        },
+        "randomatic": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.1.1.tgz",
+          "integrity": "sha512-TuDE5KxZ0J461RVjrJZCJc+J+zCkTb1MbH9AQUq68sMhOMcy9jLcb3BrZKgp9q9Ncltdg4QVqWrH02W2EFFVYw==",
+          "requires": {
+            "is-number": "^4.0.0",
+            "kind-of": "^6.0.0",
+            "math-random": "^1.0.1"
+          },
+          "dependencies": {
+            "is-number": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+              "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ=="
+            },
+            "kind-of": {
+              "version": "6.0.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+              "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+            }
+          }
+        },
+        "range-parser": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+          "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
+        },
+        "rc": {
+          "version": "1.2.8",
+          "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+          "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+          "requires": {
+            "deep-extend": "^0.6.0",
+            "ini": "~1.3.0",
+            "minimist": "^1.2.0",
+            "strip-json-comments": "~2.0.1"
+          }
+        },
+        "read-pkg": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+          "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+          "requires": {
+            "load-json-file": "^4.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^3.0.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
+          "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
+          "requires": {
+            "find-up": "^2.0.0",
+            "read-pkg": "^3.0.0"
+          }
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "readdirp": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
+          "integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
+          "requires": {
+            "graceful-fs": "^4.1.11",
+            "micromatch": "^3.1.10",
+            "readable-stream": "^2.0.2"
+          },
+          "dependencies": {
+            "arr-diff": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+              "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
+            },
+            "array-unique": {
+              "version": "0.3.2",
+              "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+              "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
+            },
+            "braces": {
+              "version": "2.3.2",
+              "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+              "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+              "requires": {
+                "arr-flatten": "^1.1.0",
+                "array-unique": "^0.3.2",
+                "extend-shallow": "^2.0.1",
+                "fill-range": "^4.0.0",
+                "isobject": "^3.0.1",
+                "repeat-element": "^1.1.2",
+                "snapdragon": "^0.8.1",
+                "snapdragon-node": "^2.0.1",
+                "split-string": "^3.0.2",
+                "to-regex": "^3.0.1"
+              },
+              "dependencies": {
+                "extend-shallow": {
+                  "version": "2.0.1",
+                  "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                  "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                  "requires": {
+                    "is-extendable": "^0.1.0"
+                  }
+                }
+              }
+            },
+            "debug": {
+              "version": "2.6.9",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
+            "expand-brackets": {
+              "version": "2.1.4",
+              "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+              "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+              "requires": {
+                "debug": "^2.3.3",
+                "define-property": "^0.2.5",
+                "extend-shallow": "^2.0.1",
+                "posix-character-classes": "^0.1.0",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.1"
+              },
+              "dependencies": {
+                "define-property": {
+                  "version": "0.2.5",
+                  "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+                  "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+                  "requires": {
+                    "is-descriptor": "^0.1.0"
+                  }
+                },
+                "extend-shallow": {
+                  "version": "2.0.1",
+                  "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                  "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                  "requires": {
+                    "is-extendable": "^0.1.0"
+                  }
+                },
+                "is-accessor-descriptor": {
+                  "version": "0.1.6",
+                  "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+                  "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+                  "requires": {
+                    "kind-of": "^3.0.2"
+                  },
+                  "dependencies": {
+                    "kind-of": {
+                      "version": "3.2.2",
+                      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                      "requires": {
+                        "is-buffer": "^1.1.5"
+                      }
+                    }
+                  }
+                },
+                "is-data-descriptor": {
+                  "version": "0.1.4",
+                  "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+                  "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+                  "requires": {
+                    "kind-of": "^3.0.2"
+                  },
+                  "dependencies": {
+                    "kind-of": {
+                      "version": "3.2.2",
+                      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                      "requires": {
+                        "is-buffer": "^1.1.5"
+                      }
+                    }
+                  }
+                },
+                "is-descriptor": {
+                  "version": "0.1.6",
+                  "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+                  "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+                  "requires": {
+                    "is-accessor-descriptor": "^0.1.6",
+                    "is-data-descriptor": "^0.1.4",
+                    "kind-of": "^5.0.0"
+                  }
+                },
+                "kind-of": {
+                  "version": "5.1.0",
+                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+                  "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
+                }
+              }
+            },
+            "extglob": {
+              "version": "2.0.4",
+              "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+              "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+              "requires": {
+                "array-unique": "^0.3.2",
+                "define-property": "^1.0.0",
+                "expand-brackets": "^2.1.4",
+                "extend-shallow": "^2.0.1",
+                "fragment-cache": "^0.2.1",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.1"
+              },
+              "dependencies": {
+                "define-property": {
+                  "version": "1.0.0",
+                  "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+                  "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+                  "requires": {
+                    "is-descriptor": "^1.0.0"
+                  }
+                },
+                "extend-shallow": {
+                  "version": "2.0.1",
+                  "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                  "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                  "requires": {
+                    "is-extendable": "^0.1.0"
+                  }
+                }
+              }
+            },
+            "fill-range": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+              "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+              "requires": {
+                "extend-shallow": "^2.0.1",
+                "is-number": "^3.0.0",
+                "repeat-string": "^1.6.1",
+                "to-regex-range": "^2.1.0"
+              },
+              "dependencies": {
+                "extend-shallow": {
+                  "version": "2.0.1",
+                  "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                  "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                  "requires": {
+                    "is-extendable": "^0.1.0"
+                  }
+                }
+              }
+            },
+            "is-accessor-descriptor": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+              "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+              "requires": {
+                "kind-of": "^6.0.0"
+              }
+            },
+            "is-data-descriptor": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+              "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+              "requires": {
+                "kind-of": "^6.0.0"
+              }
+            },
+            "is-descriptor": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+              "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+              "requires": {
+                "is-accessor-descriptor": "^1.0.0",
+                "is-data-descriptor": "^1.0.0",
+                "kind-of": "^6.0.2"
+              }
+            },
+            "is-number": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+              "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+              "requires": {
+                "kind-of": "^3.0.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "3.2.2",
+                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                  "requires": {
+                    "is-buffer": "^1.1.5"
+                  }
+                }
+              }
+            },
+            "isobject": {
+              "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+              "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+            },
+            "kind-of": {
+              "version": "6.0.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+              "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+            },
+            "micromatch": {
+              "version": "3.1.10",
+              "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+              "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+              "requires": {
+                "arr-diff": "^4.0.0",
+                "array-unique": "^0.3.2",
+                "braces": "^2.3.1",
+                "define-property": "^2.0.2",
+                "extend-shallow": "^3.0.2",
+                "extglob": "^2.0.4",
+                "fragment-cache": "^0.2.1",
+                "kind-of": "^6.0.2",
+                "nanomatch": "^1.2.9",
+                "object.pick": "^1.3.0",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.2"
+              }
+            },
+            "ms": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+            }
+          }
+        },
+        "redent": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
+          "integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
+          "requires": {
+            "indent-string": "^3.0.0",
+            "strip-indent": "^2.0.0"
+          }
+        },
+        "regex-cache": {
+          "version": "0.4.4",
+          "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
+          "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
+          "requires": {
+            "is-equal-shallow": "^0.1.3"
+          }
+        },
+        "regex-not": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
+          "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
+          "requires": {
+            "extend-shallow": "^3.0.2",
+            "safe-regex": "^1.1.0"
+          }
+        },
+        "relative-url": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/relative-url/-/relative-url-1.0.2.tgz",
+          "integrity": "sha1-0hxSpy1gYQGLzun5yfwQa/fWUoc="
+        },
+        "remark": {
+          "version": "3.2.3",
+          "resolved": "https://registry.npmjs.org/remark/-/remark-3.2.3.tgz",
+          "integrity": "sha1-gCo4w6qYyeHj6gFe66IR0ny2Xh8=",
+          "requires": {
+            "camelcase": "^2.0.0",
+            "ccount": "^1.0.0",
+            "chalk": "^1.0.0",
+            "chokidar": "^1.0.5",
+            "collapse-white-space": "^1.0.0",
+            "commander": "^2.0.0",
+            "concat-stream": "^1.0.0",
+            "debug": "^2.0.0",
+            "elegant-spinner": "^1.0.0",
+            "extend.js": "0.0.2",
+            "glob": "^6.0.1",
+            "globby": "^4.0.0",
+            "he": "^0.5.0",
+            "log-update": "^1.0.1",
+            "longest-streak": "^1.0.0",
+            "markdown-table": "^0.4.0",
+            "minimatch": "^3.0.0",
+            "npm-prefix": "^1.0.1",
+            "parse-entities": "^1.0.0",
+            "repeat-string": "^1.5.0",
+            "stringify-entities": "^1.0.0",
+            "to-vfile": "^1.0.0",
+            "trim": "^0.0.1",
+            "trim-trailing-lines": "^1.0.0",
+            "unified": "^2.0.0",
+            "user-home": "^2.0.0",
+            "vfile": "^1.1.0",
+            "vfile-find-down": "^1.0.0",
+            "vfile-find-up": "^1.0.0",
+            "vfile-reporter": "^1.5.0",
+            "ware": "^1.3.0"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "2.6.9",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
+            "ms": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+            }
+          }
+        },
+        "remark-html": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/remark-html/-/remark-html-2.0.2.tgz",
+          "integrity": "sha1-WSo0e909WIH08IDJi1sVL7FAepI=",
+          "requires": {
+            "collapse-white-space": "^1.0.0",
+            "detab": "^1.0.0",
+            "normalize-uri": "^1.0.0",
+            "object-assign": "^4.0.1",
+            "trim": "0.0.1",
+            "trim-lines": "^1.0.0",
+            "unist-util-visit": "^1.0.0"
+          }
+        },
+        "remove-trailing-separator": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+          "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
+        },
+        "repeat-element": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.3.tgz",
+          "integrity": "sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g=="
+        },
+        "repeat-string": {
+          "version": "1.6.1",
+          "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+          "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
+        },
+        "repeating": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+          "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+          "requires": {
+            "is-finite": "^1.0.0"
+          }
+        },
+        "resolve": {
+          "version": "1.10.1",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.1.tgz",
+          "integrity": "sha512-KuIe4mf++td/eFb6wkaPbMDnP6kObCaEtIDuHOUED6MNUo4K670KZUHuuvYPZDxNF0WVLw49n06M2m2dXphEzA==",
+          "requires": {
+            "path-parse": "^1.0.6"
+          }
+        },
+        "resolve-url": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+          "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
+        },
+        "restore-cursor": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
+          "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+          "requires": {
+            "exit-hook": "^1.0.0",
+            "onetime": "^1.0.0"
+          }
+        },
+        "resumer": {
+          "version": "0.0.0",
+          "resolved": "https://registry.npmjs.org/resumer/-/resumer-0.0.0.tgz",
+          "integrity": "sha1-8ej0YeQGS6Oegq883CqMiT0HZ1k=",
+          "requires": {
+            "through": "~2.3.4"
+          }
+        },
+        "ret": {
+          "version": "0.1.15",
+          "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+          "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
+        },
+        "right-pad": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/right-pad/-/right-pad-1.0.1.tgz",
+          "integrity": "sha1-jKCMLLtbVedNr6lr9/0aJ9VoyNA="
+        },
+        "rimraf": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+          "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+          "requires": {
+            "glob": "^7.1.3"
+          },
+          "dependencies": {
+            "glob": {
+              "version": "7.1.4",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+              "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+              "requires": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+              }
+            }
+          }
+        },
+        "rng": {
+          "version": "0.2.2",
+          "resolved": "https://registry.npmjs.org/rng/-/rng-0.2.2.tgz",
+          "integrity": "sha1-30PoDZvIKtRDC8/vA/SccX6LLow="
+        },
+        "run-series": {
+          "version": "1.1.8",
+          "resolved": "https://registry.npmjs.org/run-series/-/run-series-1.1.8.tgz",
+          "integrity": "sha512-+GztYEPRpIsQoCSraWHDBs9WVy4eVME16zhOtDB4H9J4xN0XRhknnmLOl+4gRgZtu8dpp9N/utSPjKH/xmDzXg=="
+        },
+        "rwlock": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/rwlock/-/rwlock-5.0.0.tgz",
+          "integrity": "sha1-iI1qd6M1HMGiCSBO8u4XIgk4Ns8="
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        },
+        "safe-regex": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+          "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+          "requires": {
+            "ret": "~0.1.10"
+          }
+        },
+        "secret-handshake": {
+          "version": "1.1.18",
+          "resolved": "https://registry.npmjs.org/secret-handshake/-/secret-handshake-1.1.18.tgz",
+          "integrity": "sha512-uP8s0ALmbJtjLEShGnJ5HHJSM1+TT8hbUme2/H2grw+WbiofSG6kr6AK1HHOmSublCVNFwfggjnWZXnEPTvIwQ==",
+          "requires": {
+            "chloride": "^2.2.8",
+            "explain-error": "^1.0.4",
+            "pull-box-stream": "^1.0.13",
+            "pull-handshake": "^1.1.1",
+            "pull-stream": "^3.4.5"
+          }
+        },
+        "secret-stack": {
+          "version": "6.1.2",
+          "resolved": "https://registry.npmjs.org/secret-stack/-/secret-stack-6.1.2.tgz",
+          "integrity": "sha512-J8JlISJnWsEapR5GOOtnFD1JuJ9QHinWzSSzPMIqoVwhz05bnwCmTQvtMRKD5Hk9WrjCrPTprubJvrrYhqHpeg==",
+          "requires": {
+            "debug": "^4.1.0",
+            "hoox": "0.0.1",
+            "ip": "^1.1.5",
+            "map-merge": "^1.1.0",
+            "multiserver": "^3.1.0",
+            "muxrpc": "^6.4.0",
+            "non-private-ip": "^1.4.3",
+            "pull-inactivity": "~2.1.1",
+            "pull-rate": "^1.0.2",
+            "pull-stream": "^3.4.5",
+            "stream-to-pull-stream": "^1.6.1",
+            "to-camel-case": "^1.0.0"
+          }
+        },
+        "semver": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
+        },
+        "separator-escape": {
+          "version": "0.0.0",
+          "resolved": "https://registry.npmjs.org/separator-escape/-/separator-escape-0.0.0.tgz",
+          "integrity": "sha1-5DNnaTICBFTjwUhwxRfqHeVsL6Q="
+        },
+        "set-value": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
+          "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
+          "requires": {
+            "extend-shallow": "^2.0.1",
+            "is-extendable": "^0.1.1",
+            "is-plain-object": "^2.0.3",
+            "split-string": "^3.0.1"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "sha.js": {
+          "version": "2.4.5",
+          "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.5.tgz",
+          "integrity": "sha1-J9Fx78yCoRi5ljn/WBZgJCtQbnw=",
+          "requires": {
+            "inherits": "^2.0.1"
+          }
+        },
+        "shebang-command": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+          "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+          "requires": {
+            "shebang-regex": "^1.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+          "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
+        },
+        "shellsubstitute": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/shellsubstitute/-/shellsubstitute-1.2.0.tgz",
+          "integrity": "sha1-5PcCpQxRiw9v6YRRiQ1wWvKba3A="
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+        },
+        "smart-buffer": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.0.2.tgz",
+          "integrity": "sha512-JDhEpTKzXusOqXZ0BUIdH+CjFdO/CR3tLlf5CN34IypI+xMmXW1uB16OOY8z3cICbJlDAVJzNbwBhNO0wt9OAw=="
+        },
+        "snapdragon": {
+          "version": "0.8.2",
+          "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
+          "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
+          "requires": {
+            "base": "^0.11.1",
+            "debug": "^2.2.0",
+            "define-property": "^0.2.5",
+            "extend-shallow": "^2.0.1",
+            "map-cache": "^0.2.2",
+            "source-map": "^0.5.6",
+            "source-map-resolve": "^0.5.0",
+            "use": "^3.1.0"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "2.6.9",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
+            "define-property": {
+              "version": "0.2.5",
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+              "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+              "requires": {
+                "is-descriptor": "^0.1.0"
+              }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            },
+            "ms": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+            }
+          }
+        },
+        "snapdragon-node": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
+          "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
+          "requires": {
+            "define-property": "^1.0.0",
+            "isobject": "^3.0.0",
+            "snapdragon-util": "^3.0.1"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+              "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+              "requires": {
+                "is-descriptor": "^1.0.0"
+              }
+            },
+            "is-accessor-descriptor": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+              "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+              "requires": {
+                "kind-of": "^6.0.0"
+              }
+            },
+            "is-data-descriptor": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+              "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+              "requires": {
+                "kind-of": "^6.0.0"
+              }
+            },
+            "is-descriptor": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+              "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+              "requires": {
+                "is-accessor-descriptor": "^1.0.0",
+                "is-data-descriptor": "^1.0.0",
+                "kind-of": "^6.0.2"
+              }
+            },
+            "isobject": {
+              "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+              "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+            },
+            "kind-of": {
+              "version": "6.0.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+              "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+            }
+          }
+        },
+        "snapdragon-util": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
+          "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
+          "requires": {
+            "kind-of": "^3.2.0"
+          }
+        },
+        "socks": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/socks/-/socks-2.3.2.tgz",
+          "integrity": "sha512-pCpjxQgOByDHLlNqlnh/mNSAxIUkyBBuwwhTcV+enZGbDaClPvHdvm6uvOwZfFJkam7cGhBNbb4JxiP8UZkRvQ==",
+          "requires": {
+            "ip": "^1.1.5",
+            "smart-buffer": "4.0.2"
+          }
+        },
+        "sodium-browserify": {
+          "version": "1.2.7",
+          "resolved": "https://registry.npmjs.org/sodium-browserify/-/sodium-browserify-1.2.7.tgz",
+          "integrity": "sha512-PGhNO8KravjroRDYvurMPRYi4xMM7zjTW10R77Nq9sjkU314YA2sPeXS6UA5k/rLHaXLaZ6YfLLVz+DdCU5w0g==",
+          "requires": {
+            "libsodium-wrappers": "^0.7.4",
+            "sha.js": "2.4.5",
+            "sodium-browserify-tweetnacl": "^0.2.5",
+            "tweetnacl": "^0.14.1"
+          }
+        },
+        "sodium-browserify-tweetnacl": {
+          "version": "0.2.6",
+          "resolved": "https://registry.npmjs.org/sodium-browserify-tweetnacl/-/sodium-browserify-tweetnacl-0.2.6.tgz",
+          "integrity": "sha512-ZnEI26hdluilpYY28Xc4rc1ALfmEp2TWihkJX6Mdtw0z9RfHfpZJU7P8DoKbN1HcBdU9aJmguFZs7igE8nLJPg==",
+          "requires": {
+            "chloride-test": "^1.1.0",
+            "ed2curve": "^0.1.4",
+            "sha.js": "^2.4.8",
+            "tweetnacl": "^1.0.1",
+            "tweetnacl-auth": "^0.3.0"
+          },
+          "dependencies": {
+            "sha.js": {
+              "version": "2.4.11",
+              "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+              "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+              "requires": {
+                "inherits": "^2.0.1",
+                "safe-buffer": "^5.0.1"
+              }
+            },
+            "tweetnacl": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.1.tgz",
+              "integrity": "sha512-kcoMoKTPYnoeS50tzoqjPY3Uv9axeuuFAZY9M/9zFnhoVvRfxz9K29IMPD7jGmt2c8SW7i3gT9WqDl2+nV7p4A=="
+            }
+          }
+        },
+        "sodium-chloride": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/sodium-chloride/-/sodium-chloride-1.1.2.tgz",
+          "integrity": "sha512-8AVzr9VHueXqfzfkzUA0aXe/Q4XG3UTmhlP6Pt+HQc5bbAPIJFo7ZIMh9tvn+99QuiMcyDJdYumegGAczl0N+g=="
+        },
+        "sodium-native": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-2.4.2.tgz",
+          "integrity": "sha512-qwHcUnzFpRSGSm6F49j/h5SnxPFBgSNdDwZkAqjvuAoHQIVBFOXYb+oCUTJV80K5hRqSYCihpbX06vbrtPbilg==",
+          "optional": true,
+          "requires": {
+            "ini": "^1.3.5",
+            "nan": "^2.4.0",
+            "node-gyp-build": "^3.0.0"
+          }
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+        },
+        "source-map-resolve": {
+          "version": "0.5.2",
+          "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
+          "integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
+          "requires": {
+            "atob": "^2.1.1",
+            "decode-uri-component": "^0.2.0",
+            "resolve-url": "^0.2.1",
+            "source-map-url": "^0.4.0",
+            "urix": "^0.1.0"
+          }
+        },
+        "source-map-url": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
+          "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
+        },
+        "spdx-correct": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
+          "integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
+          "requires": {
+            "spdx-expression-parse": "^3.0.0",
+            "spdx-license-ids": "^3.0.0"
+          }
+        },
+        "spdx-exceptions": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
+          "integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA=="
+        },
+        "spdx-expression-parse": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+          "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+          "requires": {
+            "spdx-exceptions": "^2.1.0",
+            "spdx-license-ids": "^3.0.0"
+          }
+        },
+        "spdx-license-ids": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.4.tgz",
+          "integrity": "sha512-7j8LYJLeY/Yb6ACbQ7F76qy5jHkp0U6jgBfJsk97bwWlVUnUWsAgpyaCvo17h0/RQGnQ036tVDomiwoI4pDkQA=="
+        },
+        "split-buffer": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/split-buffer/-/split-buffer-1.0.0.tgz",
+          "integrity": "sha1-t+jgq1E0UVi3LB9tvvJAbVHx0Cc="
+        },
+        "split-string": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
+          "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+          "requires": {
+            "extend-shallow": "^3.0.0"
+          }
+        },
+        "ssb-blobs": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/ssb-blobs/-/ssb-blobs-1.2.1.tgz",
+          "integrity": "sha512-3x21LBIo/TDdUVw3IPnMYyh3T31+i6Xw2v0WftiuY0djPkq3dfwQV11+t3AY6LBtKsN1jS1bpxaDZcM/npF9dA==",
+          "requires": {
+            "cont": "^1.0.3",
+            "debug": "^4.1.1",
+            "level": "^5.0.1",
+            "multiblob": "^1.12.0",
+            "pull-level": "^2.0.4",
+            "pull-notify": "^0.1.0",
+            "pull-stream": "^3.3.0",
+            "ssb-ref": "^2.3.0"
+          }
+        },
+        "ssb-caps": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/ssb-caps/-/ssb-caps-1.0.1.tgz",
+          "integrity": "sha512-ULJhokqDW4a9l7xXKPHwbhLQgRZmEjwdrrXMsPGoVYnvKb9sJuJ8ki9ilBZIs+NmYuAV+H1ffbB2Z4uioBtFYQ=="
+        },
+        "ssb-client": {
+          "version": "4.7.5",
+          "resolved": "https://registry.npmjs.org/ssb-client/-/ssb-client-4.7.5.tgz",
+          "integrity": "sha512-+GgakuweQ/oiL5EWfqQYes9+/9ooFB+QRKhbDvw1JDjya57fAmtvHhKbWZ2nzurJ1KM9iRTHU+BcZJ4xl4hr7Q==",
+          "requires": {
+            "explain-error": "^1.0.1",
+            "multicb": "^1.2.1",
+            "multiserver": "^3.1.2",
+            "muxrpc": "^6.4.2",
+            "pull-hash": "^1.0.0",
+            "pull-stream": "^3.6.0",
+            "ssb-config": "^2.3.9",
+            "ssb-keys": "^7.0.13"
+          },
+          "dependencies": {
+            "ssb-config": {
+              "version": "2.3.9",
+              "resolved": "https://registry.npmjs.org/ssb-config/-/ssb-config-2.3.9.tgz",
+              "integrity": "sha512-UF+4+khFXILLBqtu9HfrpUwYnDXIdAyJe3u9X4GrApuoakxuSKwaUGakUxLPyo6COyV2brMqufUgf+fDOI8Ftw==",
+              "requires": {
+                "deep-extend": "^0.6.0",
+                "non-private-ip": "^1.2.1",
+                "os-homedir": "^1.0.1",
+                "rc": "^1.1.6"
+              }
+            }
+          }
+        },
+        "ssb-config": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/ssb-config/-/ssb-config-3.3.0.tgz",
+          "integrity": "sha512-YJ2WvsfXPsGzyVnnYYs85mUJ67I8G9ZTGwkB95RNSboNSFfp+zNulze5QXTYq/KKQTAgV1h4pvJLIQvBr7MwUQ==",
+          "requires": {
+            "deep-extend": "^0.6.0",
+            "lodash.get": "^4.4.2",
+            "non-private-ip": "^1.2.1",
+            "os-homedir": "^1.0.1",
+            "rc": "^1.1.6",
+            "ssb-keys": "^7.1.4"
+          }
+        },
+        "ssb-db": {
+          "version": "19.2.0",
+          "resolved": "https://registry.npmjs.org/ssb-db/-/ssb-db-19.2.0.tgz",
+          "integrity": "sha512-pJAFizB6OcuJLX4RJJuU9HWyPwM2CqLi/vs08lhVIR3TGxacxpavvK5LzbxT+Y3iWkBchOTKS5hHCigA5aaung==",
+          "requires": {
+            "async-write": "^2.1.0",
+            "cont": "~1.0.0",
+            "explain-error": "~1.0.1",
+            "flumedb": "^1.0.0",
+            "flumelog-offset": "^3.3.1",
+            "flumeview-hashtable": "^1.0.3",
+            "flumeview-level": "^3.0.5",
+            "flumeview-reduce": "^1.3.9",
+            "ltgt": "^2.2.0",
+            "mdmanifest": "^1.0.8",
+            "mkdirp": "^0.5.1",
+            "monotonic-timestamp": "~0.0.8",
+            "muxrpc-validation": "^3.0.0",
+            "obv": "0.0.1",
+            "osenv": "^0.1.5",
+            "pull-cont": "^0.1.1",
+            "pull-stream": "^3.4.0",
+            "rimraf": "^2.6.2",
+            "ssb-keys": "^7.1.3",
+            "ssb-msgs": "^5.0.0",
+            "ssb-ref": "^2.12.0",
+            "ssb-validate": "^4.0.0",
+            "typewiselite": "^1.0.0",
+            "zerr": "^1.0.0"
+          }
+        },
+        "ssb-ebt": {
+          "version": "5.6.4",
+          "resolved": "https://registry.npmjs.org/ssb-ebt/-/ssb-ebt-5.6.4.tgz",
+          "integrity": "sha512-ZNqOECzKyFBJW15N8Fl4iY7MGvb1ZTBxBVjcrQy7NydJn8sbHpC7PUU3QnnNgECwzoEWkuxzkn04GHJHJypo3g==",
+          "requires": {
+            "base64-url": "^2.2.0",
+            "epidemic-broadcast-trees": "^6.3.5",
+            "lossy-store": "^1.2.3",
+            "pull-stream": "^3.5.0",
+            "push-stream-to-pull-stream": "^1.0.0",
+            "ssb-ref": "^2.9.1"
+          }
+        },
+        "ssb-feed": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/ssb-feed/-/ssb-feed-2.3.0.tgz",
+          "integrity": "sha1-uE6OApeg9ZBMTPWiAvdroeB40Ec=",
+          "requires": {
+            "cont": "~1.0.3",
+            "monotonic-timestamp": "~0.0.9",
+            "pull-stream": "^3.4.2",
+            "ssb-keys": "^7.0.0",
+            "ssb-ref": "^2.0.0"
+          }
+        },
+        "ssb-friends": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ssb-friends/-/ssb-friends-4.1.0.tgz",
+          "integrity": "sha512-Ltvlf0i+9KvVr1xjbRykrl1Ngu7lAvjuKe2vki6KYOTkQOWpSVh/weKT817J4S5ere36tLufq5HfXf5c/LGFuQ==",
+          "requires": {
+            "flumeview-reduce": "^1.3.0",
+            "layered-graph": "^1.1.1",
+            "pull-cont": "^0.1.1",
+            "pull-flatmap": "0.0.1",
+            "pull-notify": "^0.1.1",
+            "pull-stream": "^3.6.0",
+            "ssb-ref": "^2.7.1"
+          }
+        },
+        "ssb-generate": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/ssb-generate/-/ssb-generate-1.0.1.tgz",
+          "integrity": "sha1-Txconc3miluOsPALkTV3Cyy4qEU=",
+          "requires": {
+            "pull-paramap": "^1.2.2",
+            "pull-stream": "^3.6.0"
+          }
+        },
+        "ssb-gossip": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/ssb-gossip/-/ssb-gossip-1.1.0.tgz",
+          "integrity": "sha512-z4DBUtGJ+/k6z67EjavmPYAKz9BLF7zWcSDwUwLKZZT3AJp/5J6iPxHkilz2UfJ9LdGT4gF5CUe2xyIt1QFguA==",
+          "requires": {
+            "atomic-file": "^1.1.5",
+            "deep-equal": "^1.0.1",
+            "has-network": "0.0.1",
+            "ip": "^1.1.5",
+            "mdmanifest": "^1.0.8",
+            "muxrpc-validation": "^3.0.0",
+            "on-change-network": "0.0.2",
+            "on-wakeup": "^1.0.1",
+            "pull-notify": "^0.1.1",
+            "pull-ping": "^2.0.2",
+            "pull-stream": "^3.6.9",
+            "ssb-ref": "^2.13.9",
+            "statistics": "^3.3.0"
+          }
+        },
+        "ssb-invite": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ssb-invite/-/ssb-invite-2.1.3.tgz",
+          "integrity": "sha512-hHLsmlTqk6ecxpWlHiwpFNwXDfMY8gO6OdXrU2lkoqLStPrriPgzlCJnfZA06Gdi2ZL5Az4+M2fyWvnza9x/kg==",
+          "requires": {
+            "cont": "^1.0.3",
+            "explain-error": "^1.0.4",
+            "ip": "^1.1.5",
+            "level": "^5.0.0",
+            "level-sublevel": "^6.6.5",
+            "mdmanifest": "^1.0.8",
+            "muxrpc-validation": "^3.0.0",
+            "ssb-client": "^4.7.4",
+            "ssb-keys": "^7.1.3",
+            "ssb-ref": "^2.13.9"
+          }
+        },
+        "ssb-keys": {
+          "version": "7.1.6",
+          "resolved": "https://registry.npmjs.org/ssb-keys/-/ssb-keys-7.1.6.tgz",
+          "integrity": "sha512-DCl6BTz7zy7fElWgok1aBvYBfe6aUzafW1Q7z5WkpgdT8H90oqXe2l5DyTd7k77yyg82uDSjPOKfPAE9eBqfug==",
+          "requires": {
+            "chloride": "^2.2.8",
+            "mkdirp": "~0.5.0",
+            "private-box": "^0.3.0"
+          }
+        },
+        "ssb-links": {
+          "version": "3.0.6",
+          "resolved": "https://registry.npmjs.org/ssb-links/-/ssb-links-3.0.6.tgz",
+          "integrity": "sha512-X+Hhj9E1PoGS5fQMBsUMgbULLI+e93kQTrygKs9EL9nUeIOOpMelQ1XDdBUIgP40qHK8esAVVES6dWmba15TfA==",
+          "requires": {
+            "flumeview-query": "^6.0.0",
+            "map-filter-reduce": "^2.0.0",
+            "pull-stream": "^3.1.0",
+            "ssb-msgs": "^5.2.0"
+          }
+        },
+        "ssb-local": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/ssb-local/-/ssb-local-1.0.0.tgz",
+          "integrity": "sha512-aIkz+tDsAQFLbcN5d9itipHG71EG62UdIwojz78BQBxD7kGTwMezZofkMplURp9/njwdqMiqxYEUMvOh8Emh/w==",
+          "requires": {
+            "broadcast-stream": "^0.2.2",
+            "ssb-ref": "^2.13.9"
+          }
+        },
+        "ssb-logging": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/ssb-logging/-/ssb-logging-1.0.0.tgz",
+          "integrity": "sha512-6apTG47+VgLAD3MYkpRTbO27DMDh0YLJIvWfcJUEo5FdrjnLsqDl1kkzQ4B5MbH08z5Vklx5907t4by9rhlROQ==",
+          "requires": {
+            "bash-color": "0.0.4"
+          }
+        },
+        "ssb-master": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/ssb-master/-/ssb-master-1.0.2.tgz",
+          "integrity": "sha512-Sn19i0OrQYRqC8MEN7NLO8oX+/qE3fZ6VDuw6iUC7S9VIe8oh2A9bWKTGL8GR1vG5+HyxVSRo8FdgcglJDBc3g=="
+        },
+        "ssb-msgs": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/ssb-msgs/-/ssb-msgs-5.2.0.tgz",
+          "integrity": "sha1-xoHaXNcMV0ySLcpPA8UhU4E1wkM=",
+          "requires": {
+            "ssb-ref": "^2.0.0"
+          }
+        },
+        "ssb-no-auth": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/ssb-no-auth/-/ssb-no-auth-1.0.0.tgz",
+          "integrity": "sha512-+o9WnY566shLyiJp6l21+SHZfgv40SEr35PtoF3uuFYI24vFhgcfv77pXvWpDINVyX2uQ152o2eQHg1amlp6lQ==",
+          "requires": {
+            "multiserver": "^3.3.3"
+          }
+        },
+        "ssb-onion": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/ssb-onion/-/ssb-onion-1.0.0.tgz",
+          "integrity": "sha512-iRXjeI0sbRbgMwaKg+poqhHSH7GvUVgJ+8ysi8q7Hjj4wHkczLGAOyVjnyhjF+ErPDFn9kXN+46joneKqSgEDg==",
+          "requires": {
+            "multiserver": "^3.3.3"
+          }
+        },
+        "ssb-ooo": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/ssb-ooo/-/ssb-ooo-1.3.0.tgz",
+          "integrity": "sha512-xiXe+RHomaf/XAlzJm0/z8pNZeQ9bSZNAlxUgNd6loXvkCzCt1mTJptMUe+CHeHiPuLgkwFa6pN1SWIhlVd7Hg==",
+          "requires": {
+            "flumecodec": "0.0.1",
+            "flumedb": "^1.0.0",
+            "flumelog-offset": "^3.3.2",
+            "flumeview-hashtable": "^1.0.2",
+            "gossip-query": "^2.0.2",
+            "mkdirp": "^0.5.1",
+            "pull-stream": "^3.6.1",
+            "ssb-keys": "^7.1.3",
+            "ssb-ref": "^2.13.3"
+          },
+          "dependencies": {
+            "flumecodec": {
+              "version": "0.0.1",
+              "resolved": "https://registry.npmjs.org/flumecodec/-/flumecodec-0.0.1.tgz",
+              "integrity": "sha1-rgSacUOGu4PjQmV6gpJLcDZKkNY=",
+              "requires": {
+                "level-codec": "^6.2.0"
+              }
+            },
+            "level-codec": {
+              "version": "6.2.0",
+              "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-6.2.0.tgz",
+              "integrity": "sha1-pLUkS7akwvcj1oodZOmAxTYn2dQ="
+            }
+          }
+        },
+        "ssb-plugins": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/ssb-plugins/-/ssb-plugins-1.0.0.tgz",
+          "integrity": "sha512-eM8vid+K8MhwZwzk/CDUhSNhUoS6wYgq9clJrrKaP0/Otdd3zZzcBQw54Xvm0olMcOgpTSlY3m2rT4iqjZPIBw==",
+          "requires": {
+            "cross-spawn": "^6.0.5",
+            "explain-error": "^1.0.4",
+            "mdmanifest": "^1.0.8",
+            "mkdirp": "^0.5.1",
+            "muxrpc": "^6.4.0",
+            "muxrpc-validation": "^3.0.0",
+            "mv": "^2.1.1",
+            "osenv": "^0.1.5",
+            "pull-cat": "^1.1.11",
+            "pull-many": "^1.0.8",
+            "pull-pushable": "^2.2.0",
+            "pull-stream": "^3.6.9",
+            "stream-to-pull-stream": "^1.7.2"
+          }
+        },
+        "ssb-query": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/ssb-query/-/ssb-query-2.4.1.tgz",
+          "integrity": "sha512-n/WsKn2xvLp2PidaNgInGji1t6te959p1dNBdZ69rhTVOD9oR+YQ4M3z20d70F6XsUgbyFlVMSvvkfRcubVTkg==",
+          "requires": {
+            "explain-error": "^1.0.1",
+            "flumeview-query": "^7.0.0",
+            "pull-stream": "^3.6.2"
+          },
+          "dependencies": {
+            "flumeview-query": {
+              "version": "7.1.1",
+              "resolved": "https://registry.npmjs.org/flumeview-query/-/flumeview-query-7.1.1.tgz",
+              "integrity": "sha512-3HkgA4u5aIrUIFJ+uRfEpRy/xFwTresz05wf/Sg3NigWrw8JWaGMmHToJpoL8ec9EvYKgP3JNj5wHLw9WEocsA==",
+              "requires": {
+                "deep-equal": "^1.0.1",
+                "flumeview-level": "^3.0.0",
+                "map-filter-reduce": "^3.2.0",
+                "pull-flatmap": "0.0.1",
+                "pull-paramap": "^1.1.3",
+                "pull-sink-through": "0.0.0",
+                "pull-stream": "^3.4.0"
+              }
+            },
+            "map-filter-reduce": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/map-filter-reduce/-/map-filter-reduce-3.2.2.tgz",
+              "integrity": "sha512-p+NIGQbEBxlw/qWwG+NME98G/9kjOQI70hmaH8QEZtIWfTmfMYLKQW4PJChP4izPHNAxlOfv/qefP0+2ZXn84A==",
+              "requires": {
+                "binary-search": "^1.2.0",
+                "compare-at-paths": "^1.0.0",
+                "pull-sink-through": "0.0.0",
+                "pull-sort": "^1.0.1",
+                "pull-stream": "^3.4.3",
+                "typewiselite": "^1.0.0"
+              }
+            }
+          }
+        },
+        "ssb-ref": {
+          "version": "2.13.9",
+          "resolved": "https://registry.npmjs.org/ssb-ref/-/ssb-ref-2.13.9.tgz",
+          "integrity": "sha512-TfatNqLvoP+eW/pMIbCmNcaoDq4R2k8jCtWkwDKx4AtluN/LwtyP931d5Mh+2gmzA04W7kxkr6f5ENGgdadMYg==",
+          "requires": {
+            "ip": "^1.1.3",
+            "is-canonical-base64": "^1.1.1",
+            "is-valid-domain": "~0.0.1",
+            "multiserver-address": "^1.0.1"
+          }
+        },
+        "ssb-replicate": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/ssb-replicate/-/ssb-replicate-1.3.0.tgz",
+          "integrity": "sha512-FLizJ+eHtGrySb61v3asIKpZkje77a6Cl7ZotUjD3YjNUOC7y+HN0AWaupbiiFiQXDGrIZ0ti0Mr8bHkMOJurQ==",
+          "requires": {
+            "deep-equal": "^1.0.1",
+            "observ-debounce": "^1.1.1",
+            "obv": "0.0.1",
+            "pull-cat": "^1.1.11",
+            "pull-next": "^1.0.1",
+            "pull-notify": "^0.1.1",
+            "pull-paramap": "^1.2.2",
+            "pull-pushable": "^2.2.0",
+            "pull-stream": "^3.6.9",
+            "ssb-ref": "^2.13.9"
+          }
+        },
+        "ssb-unix-socket": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/ssb-unix-socket/-/ssb-unix-socket-1.0.0.tgz",
+          "integrity": "sha512-Z4jBj917W+dKAiDglwxCpWm8vINOMtkpHQIgk50NQTb5jHqHI5Rcyiy7EO0uRcWwRWqXi1ZwOTEFVyLyyuittA==",
+          "requires": {
+            "multiserver": "^3.3.3"
+          }
+        },
+        "ssb-validate": {
+          "version": "4.0.4",
+          "resolved": "https://registry.npmjs.org/ssb-validate/-/ssb-validate-4.0.4.tgz",
+          "integrity": "sha512-MojZCR1qgZHdO4pnh4Loiqxj7fxP3w+MrA/4smXoKD46ReEnOjt/8Vm2sq3qpqPmUBU2GbEoDlgw7OKy0mWJBw==",
+          "requires": {
+            "is-canonical-base64": "^1.1.1",
+            "monotonic-timestamp": "0.0.9",
+            "ssb-ref": "^2.6.2"
+          }
+        },
+        "ssb-ws": {
+          "version": "6.2.1",
+          "resolved": "https://registry.npmjs.org/ssb-ws/-/ssb-ws-6.2.1.tgz",
+          "integrity": "sha512-PR8vJVhLo8eIWfPa/NRpVWRSmASDQFS/KxHsfBmz1zGrMnLNGSW28KD5A/jVsFLDQfDlNyC75dThgUbEIki4mQ==",
+          "requires": {
+            "emoji-server": "^1.0.0",
+            "multiblob-http": "^1.0.0",
+            "multiserver": "^3.0.2",
+            "pull-box-stream": "^1.0.13",
+            "pull-stream": "^3.6.9",
+            "ssb-ref": "^2.3.0",
+            "stack": "^0.1.0"
+          }
+        },
+        "stack": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/stack/-/stack-0.1.0.tgz",
+          "integrity": "sha1-6SNZipvlHmF2gsshzxsoGKRJraI="
+        },
+        "static-extend": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
+          "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
+          "requires": {
+            "define-property": "^0.2.5",
+            "object-copy": "^0.1.0"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "0.2.5",
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+              "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+              "requires": {
+                "is-descriptor": "^0.1.0"
+              }
+            }
+          }
+        },
+        "statistics": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/statistics/-/statistics-3.3.0.tgz",
+          "integrity": "sha1-7HtHUP8DqySmTdmzV6eDFr6teKo="
+        },
+        "stream-to-pull-stream": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/stream-to-pull-stream/-/stream-to-pull-stream-1.7.3.tgz",
+          "integrity": "sha512-6sNyqJpr5dIOQdgNy/xcDWwDuzAsAwVzhzrWlAPAQ7Lkjx/rv0wgvxEyKwTq6FmNd5rjTrELt/CLmaSw7crMGg==",
+          "requires": {
+            "looper": "^3.0.0",
+            "pull-stream": "^3.2.3"
+          },
+          "dependencies": {
+            "looper": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/looper/-/looper-3.0.0.tgz",
+              "integrity": "sha1-LvpUw7HLq6m5Su4uWRSwvlf7t0k="
+            }
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        },
+        "string.prototype.trim": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.1.2.tgz",
+          "integrity": "sha1-0E3iyJ4Tf019IG8Ia17S+ua+jOo=",
+          "requires": {
+            "define-properties": "^1.1.2",
+            "es-abstract": "^1.5.0",
+            "function-bind": "^1.0.2"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        },
+        "stringify-entities": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-1.3.2.tgz",
+          "integrity": "sha512-nrBAQClJAPN2p+uGCVJRPIPakKeKWZ9GtBCmormE7pWOSlHat7+x5A8gx85M7HM5Dt0BP3pP5RhVW77WdbJJ3A==",
+          "requires": {
+            "character-entities-html4": "^1.0.0",
+            "character-entities-legacy": "^1.0.0",
+            "is-alphanumerical": "^1.0.0",
+            "is-hexadecimal": "^1.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "strip-bom": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
+        },
+        "strip-indent": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
+          "integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g="
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+        },
+        "tape": {
+          "version": "4.10.1",
+          "resolved": "https://registry.npmjs.org/tape/-/tape-4.10.1.tgz",
+          "integrity": "sha512-G0DywYV1jQeY3axeYnXUOt6ktnxS9OPJh97FGR3nrua8lhWi1zPflLxcAHavZ7Jf3qUfY7cxcVIVFa4mY2IY1w==",
+          "requires": {
+            "deep-equal": "~1.0.1",
+            "defined": "~1.0.0",
+            "for-each": "~0.3.3",
+            "function-bind": "~1.1.1",
+            "glob": "~7.1.3",
+            "has": "~1.0.3",
+            "inherits": "~2.0.3",
+            "minimist": "~1.2.0",
+            "object-inspect": "~1.6.0",
+            "resolve": "~1.10.0",
+            "resumer": "~0.0.0",
+            "string.prototype.trim": "~1.1.2",
+            "through": "~2.3.8"
+          },
+          "dependencies": {
+            "glob": {
+              "version": "7.1.4",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+              "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+              "requires": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+              }
+            }
+          }
+        },
+        "text-table": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+          "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
+        },
+        "through": {
+          "version": "2.3.8",
+          "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+          "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+        },
+        "to-camel-case": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/to-camel-case/-/to-camel-case-1.0.0.tgz",
+          "integrity": "sha1-GlYFSy+daWKYzmamCJcyK29CPkY=",
+          "requires": {
+            "to-space-case": "^1.0.0"
+          }
+        },
+        "to-fast-properties": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+          "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
+        },
+        "to-no-case": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/to-no-case/-/to-no-case-1.0.2.tgz",
+          "integrity": "sha1-xyKQcWTvaxeBMsjmmTAhLRtKoWo="
+        },
+        "to-object-path": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
+          "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+          "requires": {
+            "kind-of": "^3.0.2"
+          }
+        },
+        "to-regex": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
+          "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
+          "requires": {
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "regex-not": "^1.0.2",
+            "safe-regex": "^1.1.0"
+          }
+        },
+        "to-regex-range": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+          "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+          "requires": {
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1"
+          },
+          "dependencies": {
+            "is-number": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+              "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+              "requires": {
+                "kind-of": "^3.0.2"
+              }
+            }
+          }
+        },
+        "to-space-case": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/to-space-case/-/to-space-case-1.0.0.tgz",
+          "integrity": "sha1-sFLar7Gysp3HcM6gFj5ewOvJ/Bc=",
+          "requires": {
+            "to-no-case": "^1.0.0"
+          }
+        },
+        "to-vfile": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/to-vfile/-/to-vfile-1.0.0.tgz",
+          "integrity": "sha1-iN7+zUOtsu9ZhiXw49WffzQpQbo=",
+          "requires": {
+            "vfile": "^1.0.0"
+          }
+        },
+        "trim": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
+          "integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0="
+        },
+        "trim-lines": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-1.1.2.tgz",
+          "integrity": "sha512-3GOuyNeTqk3FAqc3jOJtw7FTjYl94XBR5aD9QnDbK/T4CA9sW/J0l9RoaRPE9wyPP7NF331qnHnvJFBJ+IDkmQ=="
+        },
+        "trim-newlines": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-2.0.0.tgz",
+          "integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA="
+        },
+        "trim-right": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+          "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
+        },
+        "trim-trailing-lines": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/trim-trailing-lines/-/trim-trailing-lines-1.1.2.tgz",
+          "integrity": "sha512-MUjYItdrqqj2zpcHFTkMa9WAv4JHTI6gnRQGPFLrt5L9a6tRMiDnIqYl8JBvu2d2Tc3lWJKQwlGCp0K8AvCM+Q=="
+        },
+        "tweetnacl": {
+          "version": "0.14.5",
+          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+          "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
+        },
+        "tweetnacl-auth": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/tweetnacl-auth/-/tweetnacl-auth-0.3.1.tgz",
+          "integrity": "sha1-t1vC3xVkm7hOi5qjwGacbEvODSU=",
+          "requires": {
+            "tweetnacl": "0.x.x"
+          }
+        },
+        "typedarray": {
+          "version": "0.0.6",
+          "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+          "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+        },
+        "typedarray-to-buffer": {
+          "version": "3.1.5",
+          "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
+          "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+          "requires": {
+            "is-typedarray": "^1.0.0"
+          }
+        },
+        "typewise": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/typewise/-/typewise-1.0.3.tgz",
+          "integrity": "sha1-EGeTZUCvl5N8xdz5kiSG6fooRlE=",
+          "requires": {
+            "typewise-core": "^1.2.0"
+          }
+        },
+        "typewise-core": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/typewise-core/-/typewise-core-1.2.0.tgz",
+          "integrity": "sha1-l+uRgFx/VdL5QXSPpQ0xXZke8ZU="
+        },
+        "typewiselite": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/typewiselite/-/typewiselite-1.0.0.tgz",
+          "integrity": "sha1-yIgvobsQksBgBal/NO9chQjjZk4="
+        },
+        "uglify-js": {
+          "version": "3.5.14",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.5.14.tgz",
+          "integrity": "sha512-dgyjIw8KFK6AyVl5vm2tEqPewv5TKGEiiVFLI1LbF+oHua/Njd8tZk3lIbF1AWU1rNdEg7scaceADb4zqCcWXg==",
+          "optional": true,
+          "requires": {
+            "commander": "~2.20.0",
+            "source-map": "~0.6.1"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.6.1",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+              "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+              "optional": true
+            }
+          }
+        },
+        "uint48be": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/uint48be/-/uint48be-2.0.1.tgz",
+          "integrity": "sha512-LQvWofTo3RCz+XaQR3VNch+dDFwpIvWr/98imhQne++vFhpQP16YAC/a8w9N00Heqqra00ACjHT18cgvn5H+bg=="
+        },
+        "ultron": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz",
+          "integrity": "sha1-rOEWq1V80Zc4ak6I9GhTeMiy5Po="
+        },
+        "unherit": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/unherit/-/unherit-1.1.2.tgz",
+          "integrity": "sha512-W3tMnpaMG7ZY6xe/moK04U9fBhi6wEiCYHUW5Mop/wQHf12+79EQGwxYejNdhEz2mkqkBlGwm7pxmgBKMVUj0w==",
+          "requires": {
+            "inherits": "^2.0.1",
+            "xtend": "^4.0.1"
+          }
+        },
+        "unified": {
+          "version": "2.1.4",
+          "resolved": "https://registry.npmjs.org/unified/-/unified-2.1.4.tgz",
+          "integrity": "sha1-FLxs1A2Y//91tAVQa62HPsu6w7o=",
+          "requires": {
+            "attach-ware": "^1.0.0",
+            "bail": "^1.0.0",
+            "extend": "^3.0.0",
+            "unherit": "^1.0.4",
+            "vfile": "^1.0.0",
+            "ware": "^1.3.0"
+          }
+        },
+        "union-value": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
+          "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
+          "requires": {
+            "arr-union": "^3.1.0",
+            "get-value": "^2.0.6",
+            "is-extendable": "^0.1.1",
+            "set-value": "^0.4.3"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            },
+            "set-value": {
+              "version": "0.4.3",
+              "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
+              "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
+              "requires": {
+                "extend-shallow": "^2.0.1",
+                "is-extendable": "^0.1.1",
+                "is-plain-object": "^2.0.1",
+                "to-object-path": "^0.3.0"
+              }
+            }
+          }
+        },
+        "unique-random": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/unique-random/-/unique-random-1.0.0.tgz",
+          "integrity": "sha1-zj4iTIJCzTOg53sNcYDXfmti0MQ="
+        },
+        "unique-random-array": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/unique-random-array/-/unique-random-array-1.0.1.tgz",
+          "integrity": "sha512-z9J/SV8CUIhIRROcHe9YUoAT6XthUJt0oUyLGgobiXJprDP9O9dsErNevvSaAv5BkhwFEVPn6nIEOKeNE6Ck1Q==",
+          "requires": {
+            "unique-random": "^1.0.0"
+          }
+        },
+        "unist-util-is": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-2.1.2.tgz",
+          "integrity": "sha512-YkXBK/H9raAmG7KXck+UUpnKiNmUdB+aBGrknfQ4EreE1banuzrKABx3jP6Z5Z3fMSPMQQmeXBlKpCbMwBkxVw=="
+        },
+        "unist-util-visit": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.4.0.tgz",
+          "integrity": "sha512-FiGu34ziNsZA3ZUteZxSFaczIjGmksfSgdKqBfOejrrfzyUy5b7YrlzT1Bcvi+djkYDituJDy2XB7tGTeBieKw==",
+          "requires": {
+            "unist-util-visit-parents": "^2.0.0"
+          }
+        },
+        "unist-util-visit-parents": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-2.1.0.tgz",
+          "integrity": "sha512-j0XZY3063E6v7qhx4+Q2Z0r8SMrLX7Mr6DabiCy67zMEcFQYtpNOplLlEK1KKEBEs9S+xB5U+yloQxbSwF9P/g==",
+          "requires": {
+            "unist-util-is": "^2.1.2"
+          }
+        },
+        "unset-value": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
+          "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
+          "requires": {
+            "has-value": "^0.3.1",
+            "isobject": "^3.0.0"
+          },
+          "dependencies": {
+            "has-value": {
+              "version": "0.3.1",
+              "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
+              "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+              "requires": {
+                "get-value": "^2.0.3",
+                "has-values": "^0.1.4",
+                "isobject": "^2.0.0"
+              },
+              "dependencies": {
+                "isobject": {
+                  "version": "2.1.0",
+                  "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+                  "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+                  "requires": {
+                    "isarray": "1.0.0"
+                  }
+                }
+              }
+            },
+            "has-values": {
+              "version": "0.1.4",
+              "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
+              "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E="
+            },
+            "isobject": {
+              "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+              "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+            }
+          }
+        },
+        "untildify": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/untildify/-/untildify-2.1.0.tgz",
+          "integrity": "sha1-F+soB5h/dpUunASF/DEdBqgmouA=",
+          "requires": {
+            "os-homedir": "^1.0.0"
+          }
+        },
+        "urix": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
+          "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI="
+        },
+        "use": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
+          "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ=="
+        },
+        "user-home": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
+          "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
+          "requires": {
+            "os-homedir": "^1.0.0"
+          }
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+        },
+        "validate-npm-package-license": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+          "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+          "requires": {
+            "spdx-correct": "^3.0.0",
+            "spdx-expression-parse": "^3.0.0"
+          }
+        },
+        "vfile": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/vfile/-/vfile-1.4.0.tgz",
+          "integrity": "sha1-wP1vpIT43r23cfaMMe112I2pf+c="
+        },
+        "vfile-find-down": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/vfile-find-down/-/vfile-find-down-1.0.0.tgz",
+          "integrity": "sha1-hKTWbQNRP2FAqE4Hdu8ISNTwrZU=",
+          "requires": {
+            "to-vfile": "^1.0.0"
+          }
+        },
+        "vfile-find-up": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/vfile-find-up/-/vfile-find-up-1.0.0.tgz",
+          "integrity": "sha1-VgTab+RTs0NQY3mE61/kkJ4oA5A=",
+          "requires": {
+            "to-vfile": "^1.0.0"
+          }
+        },
+        "vfile-reporter": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/vfile-reporter/-/vfile-reporter-1.5.0.tgz",
+          "integrity": "sha1-IacAm/5V4k34/0Mqpb9vbvp05Bg=",
+          "requires": {
+            "chalk": "^1.1.0",
+            "log-symbols": "^1.0.2",
+            "plur": "^2.0.0",
+            "repeat-string": "^1.5.0",
+            "string-width": "^1.0.0",
+            "text-table": "^0.2.0",
+            "vfile-sort": "^1.0.0"
+          }
+        },
+        "vfile-sort": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/vfile-sort/-/vfile-sort-1.0.0.tgz",
+          "integrity": "sha1-F+5JG6Q+iVG7IpE/z/MqfcTSNNQ="
+        },
+        "ware": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/ware/-/ware-1.3.0.tgz",
+          "integrity": "sha1-0bFPOdLiy0q4xAmPdW/ksWTkc9Q=",
+          "requires": {
+            "wrap-fn": "^0.1.0"
+          }
+        },
+        "which": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+          "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        },
+        "word-wrap": {
+          "version": "1.2.3",
+          "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+          "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ=="
+        },
+        "wordwrap": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
+        },
+        "wrap-fn": {
+          "version": "0.1.5",
+          "resolved": "https://registry.npmjs.org/wrap-fn/-/wrap-fn-0.1.5.tgz",
+          "integrity": "sha1-8htuQQFv9KfjFyDbxjoJAWvfmEU=",
+          "requires": {
+            "co": "3.1.0"
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+        },
+        "ws": {
+          "version": "1.1.5",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-1.1.5.tgz",
+          "integrity": "sha512-o3KqipXNUdS7wpQzBHSe180lBGO60SoK0yVo3CYJgb2MkobuWuBX6dhkYP5ORCLd55y+SaflMOV5fqAB53ux4w==",
+          "requires": {
+            "options": ">=0.0.5",
+            "ultron": "1.0.x"
+          }
+        },
+        "xtend": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+        },
+        "yargs-parser": {
+          "version": "10.1.0",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.1.0.tgz",
+          "integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
+          "requires": {
+            "camelcase": "^4.1.0"
+          },
+          "dependencies": {
+            "camelcase": {
+              "version": "4.1.0",
+              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+              "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+            }
+          }
+        },
+        "zerr": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/zerr/-/zerr-1.0.4.tgz",
+          "integrity": "sha1-YoFN15nv+DYfKiKPQfcFxeGd5Mk="
         }
       }
     },
-    "string-width": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+    "ssb-social-index": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ssb-social-index/-/ssb-social-index-1.0.0.tgz",
+      "integrity": "sha512-yj1OKkbGbHiv7dMYod45RZIgQjgGjp1i5BMg5b/1YcYvlqfKgn5X//rs2cNhiCpF1T5AOVu/o776RB9mv5s+ZA==",
+      "dev": true,
       "requires": {
-        "code-point-at": "1.1.0",
-        "is-fullwidth-code-point": "1.0.0",
-        "strip-ansi": "3.0.1"
+        "flumeview-reduce": "^1.3.9",
+        "pull-defer": "^0.2.3",
+        "pull-stream": "^3.6.9",
+        "ssb-ref": "^2.7.1"
       }
     },
     "string.prototype.trim": {
@@ -4018,182 +7473,45 @@
       "integrity": "sha1-0E3iyJ4Tf019IG8Ia17S+ua+jOo=",
       "dev": true,
       "requires": {
-        "define-properties": "1.1.2",
-        "es-abstract": "1.10.0",
-        "function-bind": "1.1.1"
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.5.0",
+        "function-bind": "^1.0.2"
       }
-    },
-    "string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-    },
-    "stringify-entities": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-1.3.1.tgz",
-      "integrity": "sha1-sVDsLXKsTBtfMktR+2soyc3/BYw=",
-      "requires": {
-        "character-entities-html4": "1.1.1",
-        "character-entities-legacy": "1.1.1",
-        "is-alphanumerical": "1.0.1",
-        "is-hexadecimal": "1.0.1"
-      }
-    },
-    "strip-ansi": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-      "requires": {
-        "ansi-regex": "2.1.1"
-      }
-    },
-    "strip-json-comments": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
-    },
-    "supports-color": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
     },
     "tape": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/tape/-/tape-4.8.0.tgz",
-      "integrity": "sha512-TWILfEnvO7I8mFe35d98F6T5fbLaEtbFTG/lxWvid8qDfFTxt19EBijWmB4j3+Hoh5TfHE2faWs73ua+EphuBA==",
+      "version": "4.11.0",
+      "resolved": "https://registry.npmjs.org/tape/-/tape-4.11.0.tgz",
+      "integrity": "sha512-yixvDMX7q7JIs/omJSzSZrqulOV51EC9dK8dM0TzImTIkHWfe2/kFyL5v+d9C+SrCMaICk59ujsqFAVidDqDaA==",
       "dev": true,
       "requires": {
-        "deep-equal": "1.0.1",
-        "defined": "1.0.0",
-        "for-each": "0.3.2",
-        "function-bind": "1.1.1",
-        "glob": "7.1.2",
-        "has": "1.0.1",
-        "inherits": "2.0.3",
-        "minimist": "1.2.0",
-        "object-inspect": "1.3.0",
-        "resolve": "1.4.0",
-        "resumer": "0.0.0",
-        "string.prototype.trim": "1.1.2",
-        "through": "2.3.8"
+        "deep-equal": "~1.0.1",
+        "defined": "~1.0.0",
+        "for-each": "~0.3.3",
+        "function-bind": "~1.1.1",
+        "glob": "~7.1.4",
+        "has": "~1.0.3",
+        "inherits": "~2.0.4",
+        "minimist": "~1.2.0",
+        "object-inspect": "~1.6.0",
+        "resolve": "~1.11.1",
+        "resumer": "~0.0.0",
+        "string.prototype.trim": "~1.1.2",
+        "through": "~2.3.8"
       },
       "dependencies": {
-        "glob": {
-          "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          }
+        "inherits": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+          "dev": true
         }
       }
-    },
-    "tar-fs": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.16.0.tgz",
-      "integrity": "sha512-I9rb6v7mjWLtOfCau9eH5L7sLJyU2BnxtEZRQ5Mt+eRKmf1F0ohXmT/Jc3fr52kDvjJ/HV5MH3soQfPL5bQ0Yg==",
-      "requires": {
-        "chownr": "1.0.1",
-        "mkdirp": "0.5.1",
-        "pump": "1.0.3",
-        "tar-stream": "1.5.5"
-      }
-    },
-    "tar-stream": {
-      "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.5.tgz",
-      "integrity": "sha512-mQdgLPc/Vjfr3VWqWbfxW8yQNiJCbAZ+Gf6GDu1Cy0bdb33ofyiNGBtAY96jHFhDuivCwgW1H9DgTON+INiXgg==",
-      "requires": {
-        "bl": "1.2.1",
-        "end-of-stream": "1.4.1",
-        "readable-stream": "2.3.3",
-        "xtend": "4.0.1"
-      },
-      "dependencies": {
-        "bl": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.1.tgz",
-          "integrity": "sha1-ysMo977kVzDUBLaSID/LWQ4XLV4=",
-          "requires": {
-            "readable-stream": "2.3.3"
-          }
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-        },
-        "readable-stream": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
-          }
-        },
-        "string_decoder": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
-        }
-      }
-    },
-    "text-table": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
     },
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
-    },
-    "to-vfile": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/to-vfile/-/to-vfile-1.0.0.tgz",
-      "integrity": "sha1-iN7+zUOtsu9ZhiXw49WffzQpQbo=",
-      "requires": {
-        "vfile": "1.4.0"
-      }
-    },
-    "trim": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
-      "integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0="
-    },
-    "trim-lines": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-1.1.0.tgz",
-      "integrity": "sha1-mSbQPt4Tuhj31CIiYx+wTHn/Jv4="
-    },
-    "trim-trailing-lines": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/trim-trailing-lines/-/trim-trailing-lines-1.1.0.tgz",
-      "integrity": "sha1-eu+7eAjfnWafbaLkOMrIxGradoQ="
-    },
-    "tunnel-agent": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
     },
     "tweetnacl": {
       "version": "0.14.5",
@@ -4205,219 +7523,13 @@
       "resolved": "https://registry.npmjs.org/tweetnacl-auth/-/tweetnacl-auth-0.3.1.tgz",
       "integrity": "sha1-t1vC3xVkm7hOi5qjwGacbEvODSU=",
       "requires": {
-        "tweetnacl": "0.14.5"
-      }
-    },
-    "typedarray": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
-    },
-    "typewise": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/typewise/-/typewise-1.0.3.tgz",
-      "integrity": "sha1-EGeTZUCvl5N8xdz5kiSG6fooRlE=",
-      "requires": {
-        "typewise-core": "1.2.0"
-      }
-    },
-    "typewise-core": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/typewise-core/-/typewise-core-1.2.0.tgz",
-      "integrity": "sha1-l+uRgFx/VdL5QXSPpQ0xXZke8ZU="
-    },
-    "typewiselite": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/typewiselite/-/typewiselite-1.0.0.tgz",
-      "integrity": "sha1-yIgvobsQksBgBal/NO9chQjjZk4="
-    },
-    "uint48be": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/uint48be/-/uint48be-1.0.2.tgz",
-      "integrity": "sha512-jNn1eEi81BLiZfJkjbiAKPDMj7iFrturKazqpBu0aJYLr6evgkn+9rgkX/gUwPBj5j2Ri5oUelsqC/S1zmpWBA=="
-    },
-    "ultron": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz",
-      "integrity": "sha1-rOEWq1V80Zc4ak6I9GhTeMiy5Po="
-    },
-    "unherit": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/unherit/-/unherit-1.1.0.tgz",
-      "integrity": "sha1-a5qu379z3xdWrZ4xbdmBiFhAzX0=",
-      "requires": {
-        "inherits": "2.0.3",
-        "xtend": "4.0.1"
-      }
-    },
-    "unified": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/unified/-/unified-2.1.4.tgz",
-      "integrity": "sha1-FLxs1A2Y//91tAVQa62HPsu6w7o=",
-      "requires": {
-        "attach-ware": "1.1.1",
-        "bail": "1.0.2",
-        "extend": "3.0.1",
-        "unherit": "1.1.0",
-        "vfile": "1.4.0",
-        "ware": "1.3.0"
-      }
-    },
-    "unist-util-is": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-2.1.1.tgz",
-      "integrity": "sha1-DDEmKeP5YMZukx6BLT2A53AQlHs="
-    },
-    "unist-util-visit": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.3.0.tgz",
-      "integrity": "sha512-9ntYcxPFtl44gnwXrQKZ5bMqXMY0ZHzUpqMFiU4zcc8mmf/jzYm8GhYgezuUlX4cJIM1zIDYaO6fG/fI+L6iiQ==",
-      "requires": {
-        "unist-util-is": "2.1.1"
-      }
-    },
-    "untildify": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/untildify/-/untildify-2.1.0.tgz",
-      "integrity": "sha1-F+soB5h/dpUunASF/DEdBqgmouA=",
-      "requires": {
-        "os-homedir": "1.0.2"
-      }
-    },
-    "unzip-response": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-1.0.2.tgz",
-      "integrity": "sha1-uYTwh3/AqJwsdzzB73tbIytbBv4="
-    },
-    "user-home": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
-      "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
-      "requires": {
-        "os-homedir": "1.0.2"
-      }
-    },
-    "util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
-    },
-    "vfile": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/vfile/-/vfile-1.4.0.tgz",
-      "integrity": "sha1-wP1vpIT43r23cfaMMe112I2pf+c="
-    },
-    "vfile-find-down": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/vfile-find-down/-/vfile-find-down-1.0.0.tgz",
-      "integrity": "sha1-hKTWbQNRP2FAqE4Hdu8ISNTwrZU=",
-      "requires": {
-        "to-vfile": "1.0.0"
-      }
-    },
-    "vfile-find-up": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/vfile-find-up/-/vfile-find-up-1.0.0.tgz",
-      "integrity": "sha1-VgTab+RTs0NQY3mE61/kkJ4oA5A=",
-      "requires": {
-        "to-vfile": "1.0.0"
-      }
-    },
-    "vfile-reporter": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/vfile-reporter/-/vfile-reporter-1.5.0.tgz",
-      "integrity": "sha1-IacAm/5V4k34/0Mqpb9vbvp05Bg=",
-      "requires": {
-        "chalk": "1.1.3",
-        "log-symbols": "1.0.2",
-        "plur": "2.1.2",
-        "repeat-string": "1.6.1",
-        "string-width": "1.0.2",
-        "text-table": "0.2.0",
-        "vfile-sort": "1.0.0"
-      }
-    },
-    "vfile-sort": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/vfile-sort/-/vfile-sort-1.0.0.tgz",
-      "integrity": "sha1-F+5JG6Q+iVG7IpE/z/MqfcTSNNQ="
-    },
-    "ware": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/ware/-/ware-1.3.0.tgz",
-      "integrity": "sha1-0bFPOdLiy0q4xAmPdW/ksWTkc9Q=",
-      "requires": {
-        "wrap-fn": "0.1.5"
-      }
-    },
-    "web-bootloader": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/web-bootloader/-/web-bootloader-0.1.2.tgz",
-      "integrity": "sha1-3hgiTOmGMz6piMOON26IGPKQJIY=",
-      "requires": {
-        "arraybuffer-base64": "1.0.0",
-        "binary-xhr": "0.0.2",
-        "hyperfile": "1.1.1",
-        "hyperprogress": "0.1.1"
-      }
-    },
-    "which": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
-      "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
-      "requires": {
-        "isexe": "2.0.0"
-      }
-    },
-    "wide-align": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
-      "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
-      "requires": {
-        "string-width": "1.0.2"
-      }
-    },
-    "word-wrap": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ=="
-    },
-    "wrap-fn": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/wrap-fn/-/wrap-fn-0.1.5.tgz",
-      "integrity": "sha1-8htuQQFv9KfjFyDbxjoJAWvfmEU=",
-      "requires": {
-        "co": "3.1.0"
+        "tweetnacl": "0.x.x"
       }
     },
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
-    },
-    "ws": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-1.1.5.tgz",
-      "integrity": "sha512-o3KqipXNUdS7wpQzBHSe180lBGO60SoK0yVo3CYJgb2MkobuWuBX6dhkYP5ORCLd55y+SaflMOV5fqAB53ux4w==",
-      "requires": {
-        "options": "0.0.6",
-        "ultron": "1.0.2"
-      }
-    },
-    "xtend": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
-    },
-    "yallist": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
-    },
-    "zerr": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/zerr/-/zerr-1.0.4.tgz",
-      "integrity": "sha1-YoFN15nv+DYfKiKPQfcFxeGd5Mk="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,12 +18,12 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "rimraf": "^2.6.2",
-    "scuttlebot": "^11.1.0",
-    "ssb-keys": "^7.0.13"
+    "rimraf": "^2.6.3",
+    "ssb-keys": "^7.1.7",
+    "ssb-server": "^15.0.2"
   },
   "devDependencies": {
-    "ssb-about": "^0.1.2",
-    "tape": "^4.8.0"
+    "ssb-about": "^2.0.1",
+    "tape": "^4.11.0"
   }
 }


### PR DESCRIPTION
While doing my village issue tracker assigment, I noticed that this repo, [ssb-testing-guide](https://github.com/ssbc/ssb-testing-guide/), makes use of this module quite a bit, so i wanted to make sure the deps were up to date.

all tests still pass. 