### PR TITLE
allow passing path as input opt

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,18 +18,18 @@ piet.publish({type: 'test', content: "a test message"}, (err, msg) => {
 
 Outputs:
 ```
-{ 
+{
   key: '%FQ2auS8kVY9qPgpTWNY3le/JG5+IlO6JHDjBIQcSPSc=.sha256',
-  value: { 
+  value: {
     previous: null,
     sequence: 1,
     author: '@UreG2i/rf4mz7QAVOtg0OML5SRRB42Cwwl3D1ct0mbU=.ed25519',
     timestamp: 1517190039755,
     hash: 'sha256',
     content: { type: 'test', content: 'a test message' },
-    signature: '0AxMJ7cKjHQ6vJDPkVNWcGND4gUwv2Z8barND5eha7ZXH/s5T0trFqcratIqzmhE3YJU2FY61Rf1S/Za2foLCA==.sig.ed25519' 
+    signature: '0AxMJ7cKjHQ6vJDPkVNWcGND4gUwv2Z8barND5eha7ZXH/s5T0trFqcratIqzmhE3YJU2FY61Rf1S/Za2foLCA==.sig.ed25519'
   },
-  timestamp: 1517190039758 
+  timestamp: 1517190039758
 }
 ```
 
@@ -47,7 +47,8 @@ By default, CreateTestSbot deletes an existing database of the same `name` befor
 
 Valid `opts` keys include:
 - `name` *String* (optional) (default: `ssb-test + Number(new Date)`)
-    - `myTestName`: Sets the database in /tmp/myTestName 
+- `path` *String* (optional) (default: `/tmp/${name}`, where `name` is the above)
+    - `~/.ssb-test`: Sets the database in `~/.ssb-test`
 - `keys` *String* (optional) (default: scuttle-testbot generates a new set of random keys)
     - you can create your own keys with `ssbKeys.generate()`
 - `startUnclean` (default: `false`)

--- a/index.js
+++ b/index.js
@@ -13,8 +13,10 @@ function createTestBot (opts = {}) {
   if (!opts.name) {
     opts.name = `ssb-test-${Date.now()}-${Math.floor(Math.random() * 1000)}`
   }
-  const folderPath = join('/tmp', opts.name)
-  if (!opts.startUnclean) { rimraf.sync(folderPath) }
+  if (!opts.path) {
+    opts.path = join(os.tmpdir(), opts.name)
+  }
+  if (!opts.startUnclean) { rimraf.sync(opts.path) }
   if (!opts.keys) { opts.keys = ssbKeys.generate() }
 
   const caps = {
@@ -28,10 +30,7 @@ function createTestBot (opts = {}) {
   plugins.forEach(plugin => createSbot.use(plugin))
   plugins = []
 
-  return createSbot({
-    ...opts,
-    path: join(os.tmpdir(), opts.name)
-  })
+  return createSbot(opts)
 }
 
 createTestBot.use = function use (plugin) {

--- a/test/index.js
+++ b/test/index.js
@@ -59,3 +59,23 @@ test('persist database across instances', (t) => {
     })
   })
 })
+
+test('allows two peers to share the same folder', (t) => {
+  const a = CreateTestSbot({ name: 'scuttle-testbot-shared' })
+
+  a.publish({ type: 'test' }, (err, val) => {
+    t.error(err, 'no error on publish')
+    a.close((err) => {
+      t.error(err, 'no error on close')
+      const b = CreateTestSbot({
+        path: '/tmp/scuttle-testbot-shared',
+        startUnclean: true,
+      })
+      b.get(val.key, (err, val) => {
+        t.error(err, 'no error on get')
+        t.ok(val, 'got message')
+        b.close(t.end)
+      })
+    })
+  })
+})

--- a/test/index.js
+++ b/test/index.js
@@ -1,4 +1,5 @@
 var test = require('tape')
+var fs = require('fs')
 var CreateTestSbot = require('../')
 
 test('creates an sbot', function (t) {
@@ -60,22 +61,15 @@ test('persist database across instances', (t) => {
   })
 })
 
-test('allows two peers to share the same folder', (t) => {
-  const a = CreateTestSbot({ name: 'scuttle-testbot-shared' })
+test('allows specifying the path to the db', (t) => {
+  const a = CreateTestSbot({ path: '/tmp/overhere/scuttle-testbot' })
 
   a.publish({ type: 'test' }, (err, val) => {
     t.error(err, 'no error on publish')
     a.close((err) => {
       t.error(err, 'no error on close')
-      const b = CreateTestSbot({
-        path: '/tmp/scuttle-testbot-shared',
-        startUnclean: true,
-      })
-      b.get(val.key, (err, val) => {
-        t.error(err, 'no error on get')
-        t.ok(val, 'got message')
-        b.close(t.end)
-      })
+      t.true(fs.existsSync('/tmp/overhere/scuttle-testbot/conn.json'))
+      t.end()
     })
   })
 })


### PR DESCRIPTION
Context: https://github.com/ssb-ngi-pointer/ssb-fixtures/pull/2

Problem: I have generated an SSB database but I want different authors (different ssb keys objects) in scuttle-testbot to share the same folder. scuttle-testbot currently make the `path` from the `name`, but this forces us to use `/tmp/something` folders.

